### PR TITLE
change(gitconfig): Use git-split-diffs instead of diff-so-fancy

### DIFF
--- a/config/.gitconfig
+++ b/config/.gitconfig
@@ -6,7 +6,7 @@
 [core]
     excludesfile = ~/.gitignore
     editor = /usr/bin/vim
-    pager = diff-so-fancy | less --tabs=2 -RFX
+    pager = git-split-diffs --color | less -RFX
 [push]
     default = current
 [alias]
@@ -43,3 +43,6 @@
 [user]
     name = Tsuyoshi HARA
     email = chloe463+git@gmail.com
+[split-diffs]
+    theme-name = arctic
+


### PR DESCRIPTION
![Screen Shot 2021-05-03 at 0 58 27](https://user-images.githubusercontent.com/6651523/116819349-b9819780-abaa-11eb-9126-bda3ea86f1c4.png)


cf. https://github.com/banga/git-split-diffs