### PR TITLE
fix(zsh): Use ctrl-b to search git branch

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -111,6 +111,6 @@ function search_branch() {
   fi
 }
 zle -N search_branch
-bindkey '^G' search_branch
+bindkey '^B' search_branch
 
 PATH=~/.console-ninja/.bin:$PATH


### PR DESCRIPTION
Git の g として brach を探すようにしていたが、連想がうまくいかない。
[B]ranch の b を取って探せるようにする。

