### PR TITLE
fix(tmux): Use 'l' instead of 'p'

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -61,9 +61,9 @@ function pwb() {
 
 # Setup tmux panes
 function ide() {
-  tmux split-window -v -p 30
-  tmux split-window -h -p 66
-  tmux split-window -h -p 50
+  tmux split-window -v -l 30%
+  tmux split-window -h -l 66%
+  tmux split-window -h -l 50%
   tmux select-pane -t 0
 }
 


### PR DESCRIPTION
To fix "Size missing" error.

