### PR TITLE
feat(terminal): improve visual appearance

### DIFF
--- a/alacritty/.config/alacritty/alacritty.toml
+++ b/alacritty/.config/alacritty/alacritty.toml
@@ -53,7 +53,7 @@ y = 2
 
 [window]
 decorations = "Buttonless"
-opacity = 0.99
+opacity = 1
 startup_mode = "Windowed"
 
 [window.padding]

--- a/alacritty/.config/alacritty/color-schemes/nord.toml
+++ b/alacritty/.config/alacritty/color-schemes/nord.toml
@@ -24,9 +24,9 @@ background = "#4c566a"  # nord3
 foreground = "CellBackground"
 background = "#88c0d0"  # nord8
 
-[colors.search.bar]
-background = "#434c5e"  # nord2
-foreground = "#d8dee9"  # Between nord4 and nord5
+# [colors.search.bar]
+# background = "#434c5e"  # nord2
+# foreground = "#d8dee9"  # Between nord4 and nord5
 
 [colors.search.focused_match]
 foreground = "#2e3440"  # nord0

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -53,6 +53,9 @@ set -g mode-style "fg=${gray_dark},bg=${blue_muted}"
 set -g pane-border-style "fg=${gray_dark}"
 set -g pane-active-border-style "fg=${gray_medium}"
 
+set -g display-panes-active-colour ${green_soft}
+set -g display-panes-colour ${gray_medium}
+
 ### KeyBindings
 ###############################################################################
 unbind ^C


### PR DESCRIPTION
## Summary
- Set Alacritty window opacity to 1.0 for full opaqueness
- Comment out Nord search bar colors in Alacritty for cleaner appearance
- Add display-panes color configuration to tmux for better pane visibility

## Test plan
- [x] Verify Alacritty window is fully opaque
- [x] Confirm Nord color scheme works without search bar colors
- [x] Test tmux display-panes command shows colored pane numbers