### PR TITLE
feat(claude): add notification hooks for permission requests

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,19 +1,6 @@
 {
   "permissions": {
     "allow": [],
-    "ask": [
-      "Bash(git push:*)",
-      "Bash(git commit:*)",
-      "Bash(git reset:*)",
-      "Bash(git rebase:*)",
-      "Bash(curl:*)",
-      "Bash(wget:*)",
-      "Bash(nc:*)",
-      "Bash(gh:*)",
-      "Bash(npm install:*)",
-      "Bash(yarn install:*)",
-      "Bash(pnpm install:*)"
-    ],
     "deny": [
       "Read(.env*)",
       "Read(.envrc)",
@@ -102,6 +89,32 @@
       "Write(~/.ssh/*_rsa)",
       "Write(~/.ssh/*_ecdsa)",
       "Write(~/.ssh/*_ed25519)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git reset:*)",
+      "Bash(git rebase:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(nc:*)",
+      "Bash(gh:*)",
+      "Bash(npm install:*)",
+      "Bash(yarn install:*)",
+      "Bash(pnpm install:*)"
+    ]
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude Codeが許可を求めています\" with title \"Claude Code\" subtitle \"確認待ち\" sound name \"Glass\"'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Reorganize permissions structure by moving ask array after deny array for better readability
- Add macOS notification hook to alert when Claude Code requests permission
- Notification displays in Japanese with Glass sound effect for better user awareness

## Test plan
- [x] Verify permissions structure is valid JSON
- [x] Test notification appears when Claude Code requests permission
- [x] Confirm notification message displays in Japanese
- [x] Verify Glass sound plays with notification