### PR TITLE
fix(zsh): disable Angular CLI autocompletion temporarily

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -154,4 +154,5 @@ zle -N search_branch
 bindkey '^B' search_branch
 
 # Load Angular CLI autocompletion.
-source <(ng completion script)
+# Temporarily disabled due to ESM/CommonJS compatibility issue
+# command -v ng > /dev/null 2>&1 && source <(ng completion script)


### PR DESCRIPTION
## Summary
- Comment out Angular CLI autocompletion due to ESM/CommonJS compatibility issue
- Add conditional check for future re-enablement when compatibility issue is resolved
- Prevents shell initialization errors when ng command is unavailable or incompatible

## Test plan
- [x] Verify zsh shell starts without errors
- [x] Confirm no Angular CLI autocompletion errors in new shell sessions
- [x] Test that other zsh configurations still work correctly