### PR TITLE
refactor(claude): restructure commands to use Skills pattern

### DIFF
--- a/claude/commands/commit.md
+++ b/claude/commands/commit.md
@@ -1,145 +1,28 @@
 ---
-name: commit
-description: Create semantic commits following conventional commits format with proper granularity
+description: Create semantic commits (uses commit Skill)
 ---
 
-# Commit Skill
+# Commit Command
 
-This skill enforces meaningful commit messages and proper commit workflow.
+This command invokes the **commit** Skill for creating semantic commits following conventional commits format.
 
-## Commit Granularity
+## Usage
 
-- **MUST**: Commit changes at logical checkpoints
-- **MUST**: Each commit includes only ONE logical change (feature, bug fix, refactor, etc.)
-- **NEVER**: Combine multiple unrelated changes into one commit
-- **NEVER**: Commit partial/broken implementations
+- **Explicit invocation**: Run `/commit`
+- **Automatic invocation**: Say "create a commit" or "generate a commit message"
 
-## Message Format
+The full commit guidelines and workflow are defined in the commit Skill.
 
-Follow the **Conventional Commits** format:
+## Quick Reference
 
-```
+```bash
+# Conventional Commits format
 <type>[optional scope]: <subject>
 
-[optional body]
-
-[optional footer]
-```
-
-### Type
-
-Must be one of:
-
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation only
-- `style`: Code style changes (formatting, missing semicolons, etc.)
-- `refactor`: Code changes that neither fix bugs nor add features
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks (dependencies, build config, etc.)
-- `ci`: CI/CD configuration changes
-
-### Scope (Optional)
-
-Indicates the affected area when applicable:
-- Examples: `auth`, `api`, `ui`, `db`, `core`, `cli`
-- Use lowercase
-- Keep it concise (1-2 words)
-- Omit if the change doesn't belong to a specific area
-
-### Subject
-
-**Describes WHAT changed**
-
-- Use imperative mood ("add" not "added" or "adds")
-- Don't capitalize first letter
-- No period at the end
-- Maximum 72 characters
-- Be specific and descriptive
-
-### Body (Optional)
-
-**Explains WHY the change was made**
-
-- Describe the reason and motivation for the change
-- Explain the problem that this change solves
-- Wrap at 72 characters
-- Separate from subject with blank line
-
-### Footer (Optional)
-
-- Breaking changes: `BREAKING CHANGE: description`
-- Issue references: `Closes #123`, `Fixes #456`
-
-## Examples
-
-### Good Commits
-
-```bash
-feat(auth): add JWT token refresh mechanism
-
-Implements automatic token refresh before expiration.
-Reduces authentication errors and improves UX.
-
-Closes #234
-```
-
-```bash
+# Examples
+feat(auth): add JWT token refresh
 fix(api): handle null response in user endpoint
-
-Previously threw uncaught exception when user not found.
-Now returns 404 with proper error message.
-```
-
-```bash
-perf(db): optimize query performance with indexes
-
-Adds composite index on (user_id, created_at).
-Reduces query time from 2s to 50ms for user dashboard.
-```
-
-```bash
 docs: update installation steps
-
-Installation steps were outdated after recent dependency changes.
 ```
 
-### Bad Commits ❌
-
-```bash
-# Too vague
-fix: bug fix
-
-# Multiple changes
-feat: add login and update user profile
-
-# Wrong tense
-fixed: bug in login
-
-# Not specific
-update code
-
-# Capitalized, has period
-Feat(auth): Add login.
-```
-
-## Workflow
-
-1. **Review changes**: `git status` and `git diff`
-2. **Stage files**: Only files related to this logical change
-3. **Write message**: Follow format above
-4. **Commit**: Create commit with meaningful message
-5. **Verify**: `git log -1` to review the commit
-
-## Co-authored Tag
-
-- Claude Code adds co-authored tag automatically
-- Keep the tag for commits (helps track AI assistance)
-- Remove tool mentions from PR descriptions per CLAUDE.md
-
-## Notes
-
-- Prefer smaller, focused commits over large commits
-- Each commit should be potentially revertible independently
-- Commit messages become part of project history - make them count
+For detailed guidelines, examples, and best practices, the commit Skill will be automatically invoked.

--- a/claude/commands/create-pr.md
+++ b/claude/commands/create-pr.md
@@ -1,193 +1,34 @@
 ---
-name: create-pr
-description: Create a GitHub pull request with meaningful description following project standards
+description: Create GitHub PR (uses create-pr Skill)
 ---
 
-# Create PR Skill
+# Create PR Command
 
-This skill creates well-structured GitHub pull requests with meaningful descriptions.
+This command invokes the **create-pr** Skill for creating well-structured GitHub pull requests.
+
+## Usage
+
+- **Explicit invocation**: Run `/create-pr`
+- **Automatic invocation**: Say "create a pull request" or "create a PR"
+
+The full PR creation guidelines and workflow are defined in the create-pr Skill.
+
+## Quick Reference
+
+```bash
+# PR Title format (Conventional Commits)
+<type>[optional scope]: <subject>
+
+# Examples
+feat(auth): add OAuth2 authentication flow
+fix(api): resolve race condition in user updates
+refactor(db): migrate to connection pooling
+```
 
 ## Prerequisites
 
-- **gh CLI installed**: Verify with `gh --version`
-- **Authenticated**: Run `gh auth status` to check
-- **Pushed branch**: Current branch must be pushed to remote
-- **Clean commits**: All commits should follow conventional commits format
+- gh CLI installed and authenticated
+- Current branch pushed to remote
+- Clean commits following conventional commits format
 
-## PR Scope
-
-- **MUST**: Review ALL commits in the branch since divergence from base
-- **MUST**: Understand the complete scope of changes, not just the latest commit
-- **NEVER**: Create PR based only on the most recent commit
-- **NEVER**: Create PR without understanding the full context
-
-## PR Title Format
-
-Follow the **Conventional Commits** format (same as commit messages):
-
-```
-<type>[optional scope]: <subject>
-```
-
-### Guidelines
-
-- Use the dominant type from commits in the branch
-- Keep it concise and descriptive (maximum 72 characters)
-- If multiple features, use the main feature or use `feat` with broader scope
-- Examples:
-  - `feat(auth): add OAuth2 authentication flow`
-  - `fix(api): resolve race condition in user updates`
-  - `refactor(db): migrate to connection pooling`
-
-## PR Description Format
-
-### Check for PR Template First
-
-Before creating the PR description, check if a PR template exists:
-
-```bash
-# Common locations for PR templates
-.github/PULL_REQUEST_TEMPLATE.md
-.github/pull_request_template.md
-.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
-docs/PULL_REQUEST_TEMPLATE.md
-```
-
-**If template exists**: Follow the template structure and fill in all sections
-**If no template**: Use the default format below
-
-### Default Format (when no template exists)
-
-```markdown
-## Summary
-
-Brief overview of what this PR does (2-4 bullet points)
-
-## Why
-
-Explain the motivation and context for this change:
-- What problem does this solve?
-- Why is this change necessary?
-- What is the business value or technical benefit?
-
-## Changes
-
-- List major changes or components affected
-- Group related changes together
-- Mention any breaking changes
-
-## Test Plan
-
-- [ ] Describe how to test the changes
-- [ ] List manual testing steps if applicable
-- [ ] Mention automated tests added/updated
-
-## Notes
-
-[Optional section for additional context]
-- Any caveats or known limitations
-- Follow-up work needed
-- Performance impact (if relevant)
-- Migration steps (if applicable)
-```
-
-## Workflow
-
-1. **Check for PR template**
-   - Look for PR template in common locations
-   - Read and understand the template structure if it exists
-
-2. **Analyze branch history**
-   - Run `git log <base-branch>...HEAD` to see all commits
-   - Run `git diff <base-branch>...HEAD` to understand full changes
-   - Review commit messages to understand the scope
-
-3. **Verify branch state**
-   - Check if branch is pushed: `git status`
-   - Push if needed: `git push -u origin <branch-name>`
-
-4. **Draft PR content**
-   - Create title based on the dominant change type
-   - Write description following template (if exists) or default format
-   - Ensure all sections are filled appropriately
-
-5. **Create PR**
-   - Use `gh pr create --title "..." --body "..."`
-   - Add reviewers if configured
-   - Set base branch if not default
-
-6. **Verify PR**
-   - Return the PR URL for user review
-   - Check that description is clear and complete
-
-## Examples
-
-### Good PR with Default Format
-
-**Title:** `feat(auth): add JWT token refresh mechanism`
-
-**Description:**
-```markdown
-## Summary
-
-- Implements automatic JWT token refresh before expiration
-- Reduces authentication errors and improves user experience
-- Adds background refresh logic with configurable timing
-
-## Why
-
-Users were experiencing frequent authentication errors when tokens expired
-during active sessions. This implementation proactively refreshes tokens
-before expiration, eliminating interruptions and improving UX.
-
-## Changes
-
-- Add `TokenRefreshService` for managing token lifecycle
-- Update authentication middleware to handle token refresh
-- Add configuration options for refresh timing
-- Include comprehensive error handling and logging
-
-## Test Plan
-
-- [ ] Verify token refresh works before expiration
-- [ ] Test error handling when refresh fails
-- [ ] Confirm existing authentication flows still work
-- [ ] Run integration tests for auth endpoints
-
-## Notes
-
-Performance impact: Minimal, refresh happens in background.
-```
-
-### Bad PR Examples ❌
-
-```
-# Too vague
-fix: bug fixes
-
-# Not descriptive
-Update code
-
-# Multiple unrelated changes
-feat: add login, fix user profile, update tests, refactor API
-
-# Missing Why section
-Just implements the feature without explaining motivation
-```
-
-## PR Guidelines (from CLAUDE.md)
-
-- **Focus on high-level problem and solution**
-- **Never mention tools used** (no "Generated by Claude Code", no co-authored-by)
-- **Add specific reviewers** as configured in repository settings
-- **Include performance impact** if relevant to the changes
-- **Keep descriptions clear and concise**
-
-## Notes
-
-- PR description should be self-contained and explain the context
-- Assume reviewers may not have full context of discussions
-- Link to related issues if applicable: `Closes #123`, `Relates to #456`
-- For large PRs, consider breaking into smaller, focused PRs
-- Each PR should ideally address one logical feature or fix
-- Always respect project-specific PR templates when they exist
+For detailed guidelines, PR templates, examples, and best practices, the create-pr Skill will be automatically invoked.

--- a/claude/skills/commit/SKILL.md
+++ b/claude/skills/commit/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: commit
+description: Create semantic commits following conventional commits format with proper granularity
+---
+
+# Commit Skill
+
+This skill enforces meaningful commit messages and proper commit workflow.
+
+## Commit Granularity
+
+- **MUST**: Commit changes at logical checkpoints
+- **MUST**: Each commit includes only ONE logical change (feature, bug fix, refactor, etc.)
+- **NEVER**: Combine multiple unrelated changes into one commit
+- **NEVER**: Commit partial/broken implementations
+
+## Branch Policy
+
+**CRITICAL: Protect main/master branches**
+
+- **NEVER**: Commit directly to `main` or `master` branches
+- **MUST**: Work on feature branches (e.g., `feature/add-auth`, `fix/login-bug`)
+- **MUST**: Merge changes via pull requests only
+- **EXCEPTION**: Only commit to `main`/`master` if the user explicitly requests it
+
+### Before Committing
+
+Always check the current branch:
+
+```bash
+git branch --show-current
+```
+
+**If on main/master**:
+1. **STOP** - Do not commit
+2. Create a feature branch: `git checkout -b feature/descriptive-name`
+3. Then commit your changes
+4. Push and create a pull request
+
+**Exception**: If the user explicitly says "commit to main" or "commit to master", then proceed.
+
+## Message Format
+
+Follow the **Conventional Commits** format:
+
+```
+<type>[optional scope]: <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+### Type
+
+Must be one of:
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Code style changes (formatting, missing semicolons, etc.)
+- `refactor`: Code changes that neither fix bugs nor add features
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks (dependencies, build config, etc.)
+- `ci`: CI/CD configuration changes
+
+### Scope (Optional)
+
+Indicates the affected area when applicable:
+- Examples: `auth`, `api`, `ui`, `db`, `core`, `cli`
+- Use lowercase
+- Keep it concise (1-2 words)
+- Omit if the change doesn't belong to a specific area
+
+### Subject
+
+**Describes WHAT changed**
+
+- Use imperative mood ("add" not "added" or "adds")
+- Don't capitalize first letter
+- No period at the end
+- Maximum 72 characters
+- Be specific and descriptive
+
+### Body (Optional)
+
+**Explains WHY the change was made**
+
+- Describe the reason and motivation for the change
+- Explain the problem that this change solves
+- Wrap at 72 characters
+- Separate from subject with blank line
+
+### Footer (Optional)
+
+- Breaking changes: `BREAKING CHANGE: description`
+- Issue references: `Closes #123`, `Fixes #456`
+
+## Examples
+
+### Good Commits
+
+```bash
+feat(auth): add JWT token refresh mechanism
+
+Implements automatic token refresh before expiration.
+Reduces authentication errors and improves UX.
+
+Closes #234
+```
+
+```bash
+fix(api): handle null response in user endpoint
+
+Previously threw uncaught exception when user not found.
+Now returns 404 with proper error message.
+```
+
+```bash
+perf(db): optimize query performance with indexes
+
+Adds composite index on (user_id, created_at).
+Reduces query time from 2s to 50ms for user dashboard.
+```
+
+```bash
+docs: update installation steps
+
+Installation steps were outdated after recent dependency changes.
+```
+
+### Bad Commits ❌
+
+```bash
+# Too vague
+fix: bug fix
+
+# Multiple changes
+feat: add login and update user profile
+
+# Wrong tense
+fixed: bug in login
+
+# Not specific
+update code
+
+# Capitalized, has period
+Feat(auth): Add login.
+```
+
+## Workflow
+
+1. **Check branch**: Verify not on `main`/`master` with `git branch --show-current`
+2. **Review changes**: `git status` and `git diff`
+3. **Stage files**: Only files related to this logical change
+4. **Write message**: Follow format above
+5. **Commit**: Create commit with meaningful message
+6. **Verify**: `git log -1` to review the commit
+
+## Co-authored Tag
+
+- Claude Code adds co-authored tag automatically
+- Keep the tag for commits (helps track AI assistance)
+- Remove tool mentions from PR descriptions per CLAUDE.md
+
+## Notes
+
+- Prefer smaller, focused commits over large commits
+- Each commit should be potentially revertible independently
+- Commit messages become part of project history - make them count

--- a/claude/skills/create-pr/SKILL.md
+++ b/claude/skills/create-pr/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: create-pr
+description: Create a GitHub pull request with meaningful description following project standards
+---
+
+# Create PR Skill
+
+This skill creates well-structured GitHub pull requests with meaningful descriptions.
+
+## Prerequisites
+
+- **gh CLI installed**: Verify with `gh --version`
+- **Authenticated**: Run `gh auth status` to check
+- **Pushed branch**: Current branch must be pushed to remote
+- **Clean commits**: All commits should follow conventional commits format
+
+## PR Scope
+
+- **MUST**: Review ALL commits in the branch since divergence from base
+- **MUST**: Understand the complete scope of changes, not just the latest commit
+- **NEVER**: Create PR based only on the most recent commit
+- **NEVER**: Create PR without understanding the full context
+
+## PR Title Format
+
+Follow the **Conventional Commits** format (same as commit messages):
+
+```
+<type>[optional scope]: <subject>
+```
+
+### Guidelines
+
+- Use the dominant type from commits in the branch
+- Keep it concise and descriptive (maximum 72 characters)
+- If multiple features, use the main feature or use `feat` with broader scope
+- Examples:
+  - `feat(auth): add OAuth2 authentication flow`
+  - `fix(api): resolve race condition in user updates`
+  - `refactor(db): migrate to connection pooling`
+
+## PR Description Format
+
+### Check for PR Template First
+
+Before creating the PR description, check if a PR template exists:
+
+```bash
+# Common locations for PR templates
+.github/PULL_REQUEST_TEMPLATE.md
+.github/pull_request_template.md
+.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+docs/PULL_REQUEST_TEMPLATE.md
+```
+
+**If template exists**: Follow the template structure and fill in all sections
+**If no template**: Use the default format below
+
+### Default Format (when no template exists)
+
+```markdown
+## Summary
+
+Brief overview of what this PR does (2-4 bullet points)
+
+## Why
+
+Explain the motivation and context for this change:
+- What problem does this solve?
+- Why is this change necessary?
+- What is the business value or technical benefit?
+
+## Changes
+
+- List major changes or components affected
+- Group related changes together
+- Mention any breaking changes
+
+## Test Plan
+
+- [ ] Describe how to test the changes
+- [ ] List manual testing steps if applicable
+- [ ] Mention automated tests added/updated
+
+## Notes
+
+[Optional section for additional context]
+- Any caveats or known limitations
+- Follow-up work needed
+- Performance impact (if relevant)
+- Migration steps (if applicable)
+```
+
+## Workflow
+
+1. **Check for PR template**
+   - Look for PR template in common locations
+   - Read and understand the template structure if it exists
+
+2. **Analyze branch history**
+   - Run `git log <base-branch>...HEAD` to see all commits
+   - Run `git diff <base-branch>...HEAD` to understand full changes
+   - Review commit messages to understand the scope
+
+3. **Verify branch state**
+   - Check if branch is pushed: `git status`
+   - Push if needed: `git push -u origin <branch-name>`
+
+4. **Draft PR content**
+   - Create title based on the dominant change type
+   - Write description following template (if exists) or default format
+   - Ensure all sections are filled appropriately
+
+5. **Create PR**
+   - Use `gh pr create --title "..." --body "..."`
+   - Add reviewers if configured
+   - Set base branch if not default
+
+6. **Verify PR**
+   - Return the PR URL for user review
+   - Check that description is clear and complete
+
+## Examples
+
+### Good PR with Default Format
+
+**Title:** `feat(auth): add JWT token refresh mechanism`
+
+**Description:**
+```markdown
+## Summary
+
+- Implements automatic JWT token refresh before expiration
+- Reduces authentication errors and improves user experience
+- Adds background refresh logic with configurable timing
+
+## Why
+
+Users were experiencing frequent authentication errors when tokens expired
+during active sessions. This implementation proactively refreshes tokens
+before expiration, eliminating interruptions and improving UX.
+
+## Changes
+
+- Add `TokenRefreshService` for managing token lifecycle
+- Update authentication middleware to handle token refresh
+- Add configuration options for refresh timing
+- Include comprehensive error handling and logging
+
+## Test Plan
+
+- [ ] Verify token refresh works before expiration
+- [ ] Test error handling when refresh fails
+- [ ] Confirm existing authentication flows still work
+- [ ] Run integration tests for auth endpoints
+
+## Notes
+
+Performance impact: Minimal, refresh happens in background.
+```
+
+### Bad PR Examples ❌
+
+```
+# Too vague
+fix: bug fixes
+
+# Not descriptive
+Update code
+
+# Multiple unrelated changes
+feat: add login, fix user profile, update tests, refactor API
+
+# Missing Why section
+Just implements the feature without explaining motivation
+```
+
+## PR Guidelines (from CLAUDE.md)
+
+- **Focus on high-level problem and solution**
+- **Never mention tools used** (no "Generated by Claude Code", no co-authored-by)
+- **Add specific reviewers** as configured in repository settings
+- **Include performance impact** if relevant to the changes
+- **Keep descriptions clear and concise**
+
+## Notes
+
+- PR description should be self-contained and explain the context
+- Assume reviewers may not have full context of discussions
+- Link to related issues if applicable: `Closes #123`, `Relates to #456`
+- For large PRs, consider breaking into smaller, focused PRs
+- Each PR should ideally address one logical feature or fix
+- Always respect project-specific PR templates when they exist


### PR DESCRIPTION
## Summary

- Refactors Claude Code commands to use the Skills + lightweight commands architecture
- Moves full content from commands to dedicated Skills directories
- Adds branch policy protection to prevent direct commits to main/master
- Eliminates content duplication between commands and skills

## Why

Previously, the commit and create-pr functionality lived in the commands directory. To enable both explicit command invocation (`/commit`) and automatic skill discovery ("create a commit"), we needed to either duplicate content or find a better structure.

This PR implements the recommended pattern from Claude Code documentation: Skills as the primary mechanism with lightweight command references.

## Changes

- **claude/commands/commit.md**: Reduced to 28 lines (lightweight reference to commit skill)
- **claude/commands/create-pr.md**: Reduced to 34 lines (lightweight reference to create-pr skill)
- **claude/skills/commit/SKILL.md**: Created with full commit guidelines (171 lines)
  - Added branch policy section to prevent direct commits to main/master
  - Includes comprehensive workflow and examples
- **claude/skills/create-pr/SKILL.md**: Created with full PR creation guidelines (193 lines)
  - Includes PR template detection and format guidelines

## Test Plan

- [x] Test explicit command invocation with `/commit` and `/create-pr`
- [ ] Test automatic skill discovery with natural language
- [ ] Verify branch policy prevents commits to main/master
- [ ] Re-stow dotfiles with `stow -R claude` to update symlinks

## Notes

After merging, run `cd ~/dotfiles && stow -R claude` to update the `~/.claude` symlinks with the new structure.

Net change: +396 insertions, -308 deletions (code reorganization)