### PR TITLE
chore(claude): update settings and documentation

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -257,6 +257,35 @@ git commit -m "refactor(core): extract validation logic"
 - Add specific reviewers as configured
 - Include performance impact if relevant
 
+## 🔍 GitHub PR Review Comments via API
+
+When posting PR review comments with inline comments using `gh api`, follow these rules to avoid HTTP 422 errors:
+
+1. **Use `--input` (not `--field`)** for the request body — `--field` cannot handle nested JSON arrays like `comments`
+2. **Always include `commit_id`** — resolve it first with `gh pr view {N} --json headRefOid --jq '.headRefOid'`
+3. **Always include `"side": "RIGHT"` on each comment** — tells GitHub the comment targets the new (post-change) side of the diff
+4. **Write JSON payload to a temp file** — avoids shell escaping issues with inline heredocs
+
+```bash
+# Template
+COMMIT_SHA=$(gh pr view {N} --json headRefOid --jq '.headRefOid')
+
+# Write JSON to file (use Write tool, not heredoc, to avoid escaping issues)
+# Required fields in JSON:
+# {
+#   "commit_id": "<COMMIT_SHA>",
+#   "event": "COMMENT",
+#   "body": "Review summary",
+#   "comments": [
+#     { "path": "file.ts", "line": 42, "side": "RIGHT", "body": "Comment" }
+#   ]
+# }
+
+gh api repos/{owner}/{repo}/pulls/{N}/reviews \
+  --method POST \
+  --input /tmp/pr-review.json
+```
+
 ---
 
 Remember: **Engineer time is gold** - Automate everything, document comprehensively, and proactively suggest improvements. Every interaction should save time and improve code quality.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -5,6 +5,7 @@
       "Read(.env*)",
       "Read(.envrc)",
       "Read(id_rsa)",
+      "Read(**/.credentials.zsh)",
       "Read(**/*token*)",
       "Read(**/*key*)",
       "Read(**/*secret*)",
@@ -123,7 +124,11 @@
     "padding": 0
   },
   "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": true
+    "example-skills@anthropic-agent-skills": true,
+    "pr-review-toolkit@claude-plugins-official": true
   },
-  "model": "sonnet"
+  "language": "Japanese",
+  "autoUpdatesChannel": "latest",
+  "theme": "dark-ansi",
+  "model": "opus"
 }

--- a/claude/skills/commit/SKILL.md
+++ b/claude/skills/commit/SKILL.md
@@ -19,8 +19,11 @@ This skill enforces meaningful commit messages and proper commit workflow.
 **CRITICAL: Protect main/master branches**
 
 - **NEVER**: Commit directly to `main` or `master` branches
-- **MUST**: Work on feature branches (e.g., `feature/add-auth`, `fix/login-bug`)
+- **MUST**: Work on feature branches (e.g., `chloe463/feature/add-auth`, `chloe463/fix/login-bug`)
 - **MUST**: Merge changes via pull requests only
+- **SHOULD**: Add GitHub account name (`chloe463`) to branch name as a prefix
+    - **MUST** add prefix when the repository owner/org is NOT `chloe463` (e.g., `chloe463/feature/add-auth`)
+    - **MAY** omit prefix when the repository owner/org is `chloe463`
 - **EXCEPTION**: Only commit to `main`/`master` if the user explicitly requests it
 
 ### Before Committing


### PR DESCRIPTION
## Summary

Claude Code の設定とドキュメントをまとめて更新。

- **settings.json**: モデルを sonnet → opus に変更、`pr-review-toolkit` プラグインを有効化、language/theme/autoUpdatesChannel を追加、`.credentials.zsh` の読み取りを deny
- **CLAUDE.md**: `gh api` で PR review コメントを投稿する際の落とし穴（HTTP 422 回避策）をドキュメント化
- **commit skill (SKILL.md)**: ブランチ名に `chloe463/` prefix を付けるルールを追加（自分が owner でない repo では必須）

## Test plan

- [ ] Claude Code を再起動して設定が反映されることを確認
- [ ] `/plugin` で `pr-review-toolkit` が有効になっていることを確認
- [ ] 次のコミット skill 起動時にブランチ prefix ルールが参照されることを確認