### PR TITLE
chore(git): improve url rewrite and ignore patterns

### DIFF
--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -47,3 +47,5 @@
 [split-diffs]
     theme-name = arctic
 
+[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/

--- a/git/.config/git/ignore
+++ b/git/.config/git/ignore
@@ -28,3 +28,7 @@ telepresence.log
 **/.claude/settings.local.json
 .ai_logs/
 
+.worktrees
+
+# GitHub CLI per-machine auth state
+**/.config/gh/hosts.yml


### PR DESCRIPTION
## Summary

Git の global config / ignore を改善。

- **config**: `url.ssh://git@github.com/.insteadOf https://github.com/` を追加。HTTPS で表記された GitHub URL を透過的に SSH へ書き換え。
- **ignore**:
  - `.worktrees` — ローカルの git worktree ディレクトリ
  - `**/.config/gh/hosts.yml` — GitHub CLI のマシン固有な認証状態（OAuth トークンを含む可能性あり）

## Test plan

- [ ] `git clone https://github.com/<owner>/<repo>` が SSH 経由で動作することを確認
- [ ] `gh auth login` 後に `gh/.config/gh/hosts.yml` が `git status` に出ないことを確認
- [x] `.worktrees/` ディレクトリを作成しても `git status` がクリーンなままであることを確認