### PR TITLE
feat(statusline): add rate limit display and AWS Bedrock detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,15 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Type check
         run: bun typecheck
+  test-claude-statusline:
+    name: Test statusline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run test
+        run: bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Type check
-        run: bunx tsc --noEmit
+        run: bun typecheck

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "devDependencies": {
         "@types/bun": "latest",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -14,6 +15,8 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "configVersion": 1,
   "workspaces": {
     "": {
+      "dependencies": {
+        "chalk": "^5.6.2",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^6.0.3",
@@ -12,9 +15,11 @@
   "packages": {
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/claude/statusline.test.ts
+++ b/claude/statusline.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "bun:test";
-import { isRateLimit, isStatuslineInput, formatResetTime } from "./statusline";
+import { isRateLimit, isStatuslineInput, formatResetTime, extractModelName } from "./statusline";
 
 describe("isRateLimit", () => {
   it("returns true for valid RateLimit", () => {
@@ -74,6 +74,38 @@ describe("isStatuslineInput", () => {
         rate_limits: { seven_day: { used_percentage: 80, resets_at: Infinity } },
       }),
     ).toBe(false);
+  });
+});
+
+describe("extractModelName", () => {
+  it("returns display_name for a regular model", () => {
+    expect(extractModelName({ id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" })).toBe(
+      "Claude Sonnet 4.6",
+    );
+  });
+  it("returns display_name when id is undefined", () => {
+    expect(extractModelName({ display_name: "Claude Sonnet 4.6" })).toBe("Claude Sonnet 4.6");
+  });
+  it("shortens ARN display_name to last path segment and appends 'by AWS'", () => {
+    expect(
+      extractModelName({
+        id: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        display_name: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0",
+      }),
+    ).toBe("anthropic.claude-3-5-sonnet-20241022-v2:0 by AWS");
+  });
+  it("appends 'by AWS' when id is an ARN but display_name is friendly", () => {
+    expect(
+      extractModelName({
+        id: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        display_name: "Claude 3.5 Sonnet",
+      }),
+    ).toBe("Claude 3.5 Sonnet by AWS");
+  });
+  it("falls back to full ARN when path has no slash", () => {
+    expect(
+      extractModelName({ id: "arn:no-slash", display_name: "arn:no-slash" }),
+    ).toBe("arn:no-slash by AWS");
   });
 });
 

--- a/claude/statusline.test.ts
+++ b/claude/statusline.test.ts
@@ -1,0 +1,97 @@
+import { expect, describe, it } from "bun:test";
+import { isRateLimit, isStatuslineInput, formatResetTime } from "./statusline";
+
+describe("isRateLimit", () => {
+  it("returns true for valid RateLimit", () => {
+    expect(isRateLimit({ used_percentage: 50, resets_at: 1700000000 })).toBe(true);
+  });
+  it("returns false for null", () => {
+    expect(isRateLimit(null)).toBe(false);
+  });
+  it("returns false for non-object", () => {
+    expect(isRateLimit("string")).toBe(false);
+    expect(isRateLimit(42)).toBe(false);
+  });
+  it("returns false when used_percentage is missing", () => {
+    expect(isRateLimit({ resets_at: 1700000000 })).toBe(false);
+  });
+  it("returns false when resets_at is NaN", () => {
+    expect(isRateLimit({ used_percentage: 50, resets_at: NaN })).toBe(false);
+  });
+  it("returns false when resets_at is Infinity", () => {
+    expect(isRateLimit({ used_percentage: 50, resets_at: Infinity })).toBe(false);
+  });
+});
+
+describe("isStatuslineInput", () => {
+  it("returns true for minimal valid input", () => {
+    expect(
+      isStatuslineInput({
+        model: { display_name: "Claude Sonnet 4.6" },
+        workspace: { current_dir: "/home/user/project" },
+      }),
+    ).toBe(true);
+  });
+  it("returns true with optional fields present", () => {
+    expect(
+      isStatuslineInput({
+        model: { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+        workspace: { current_dir: "/home/user/project" },
+        rate_limits: {
+          five_hour: { used_percentage: 30, resets_at: 1700000000 },
+          seven_day: { used_percentage: 60, resets_at: 1700000000 },
+        },
+      }),
+    ).toBe(true);
+  });
+  it("returns false for null", () => {
+    expect(isStatuslineInput(null)).toBe(false);
+  });
+  it("returns false when model.display_name is missing", () => {
+    expect(
+      isStatuslineInput({ model: {}, workspace: { current_dir: "/home" } }),
+    ).toBe(false);
+  });
+  it("returns false when workspace.current_dir is missing", () => {
+    expect(
+      isStatuslineInput({ model: { display_name: "Claude" }, workspace: {} }),
+    ).toBe(false);
+  });
+  it("returns false when five_hour has invalid resets_at", () => {
+    expect(
+      isStatuslineInput({
+        model: { display_name: "Claude" },
+        workspace: { current_dir: "/home" },
+        rate_limits: { five_hour: { used_percentage: 50, resets_at: NaN } },
+      }),
+    ).toBe(false);
+  });
+  it("returns false when seven_day has invalid resets_at", () => {
+    expect(
+      isStatuslineInput({
+        model: { display_name: "Claude" },
+        workspace: { current_dir: "/home" },
+        rate_limits: { seven_day: { used_percentage: 80, resets_at: Infinity } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("formatResetTime", () => {
+  it("returns ??:?? for 0", () => {
+    expect(formatResetTime(0)).toBe("??:??");
+  });
+  it("returns ??:?? for negative values", () => {
+    expect(formatResetTime(-1)).toBe("??:??");
+  });
+  it("returns ??:?? for NaN", () => {
+    expect(formatResetTime(NaN)).toBe("??:??");
+  });
+  it("returns ??:?? for Infinity", () => {
+    expect(formatResetTime(Infinity)).toBe("??:??");
+  });
+  it("returns HH:MM format for a valid timestamp", () => {
+    const result = formatResetTime(1700000000);
+    expect(result).toMatch(/^\d{2}:\d{2}$/);
+  });
+});

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -61,8 +61,16 @@ function isStatuslineInput(value: unknown): value is StatuslineInput {
   const rl = v.rate_limits;
   if (rl !== undefined && typeof rl === "object" && rl !== null) {
     const rateLimits = rl as Record<string, unknown>;
-    if (rateLimits.five_hour !== undefined && !isRateLimit(rateLimits.five_hour)) return false;
-    if (rateLimits.seven_day !== undefined && !isRateLimit(rateLimits.seven_day)) return false;
+    if (
+      rateLimits.five_hour !== undefined &&
+      !isRateLimit(rateLimits.five_hour)
+    )
+      return false;
+    if (
+      rateLimits.seven_day !== undefined &&
+      !isRateLimit(rateLimits.seven_day)
+    )
+      return false;
   }
   return true;
 }
@@ -103,7 +111,7 @@ if (!isStatuslineInput(data)) {
   log("ERROR", `invalid input shape: ${JSON.stringify(data)}`);
   process.exit(1);
 }
-log("INFO", `stdin fields: ${Object.keys(data as Record<string, unknown>).join(", ")}`);
+log("INFO", `stdin fields: ${Object.keys(data).join(", ")}`);
 
 const isAwsBedrock = data.model.id?.startsWith("arn:") ?? false;
 const modelDisplayName = isAwsBedrock

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -1,8 +1,14 @@
 #!/usr/bin/env bun
 
+import { format } from "node:util";
 import { execSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import path from "node:path";
+
+import chalk from "chalk";
+
+// NOTE: Set level 3 to affect colors in the statusline.
+chalk.level = 3;
 
 const DEBUG = process.env.STATUSLINE_DEBUG === "1";
 const LOG_FILE = process.env.STATUSLINE_LOG_FILE ?? "/tmp/statusline.log";
@@ -15,6 +21,16 @@ function log(level: "INFO" | "ERROR", message: string): void {
   } catch {
     // ログ書き込み失敗でstatuslineをクラッシュさせない
   }
+}
+
+function renderClaudeBrandColor(msg: string) {
+  return chalk.hex("#DE7356")(msg);
+}
+
+function renderRatio(msg: string, ratio: number) {
+  if (ratio < 50) return chalk.reset(format(msg, ratio));
+  if (ratio < 75) return chalk.yellow(format(msg, ratio));
+  return chalk.red(format(msg, ratio));
 }
 
 interface ContextWindow {
@@ -134,7 +150,7 @@ try {
   log("ERROR", `git branch failed: ${message}`);
 }
 
-let contextInfo = "";
+let contextInfo = 0;
 const contextSize = data.context_window?.context_window_size;
 const currentUsage = data.context_window?.current_usage;
 if (currentUsage && contextSize && contextSize > 0) {
@@ -142,12 +158,14 @@ if (currentUsage && contextSize && contextSize > 0) {
     (currentUsage.input_tokens ?? 0) +
     (currentUsage.cache_creation_input_tokens ?? 0) +
     (currentUsage.cache_read_input_tokens ?? 0);
-  contextInfo = `${Math.floor((currentTokens * 100) / contextSize)}%`;
+  contextInfo = Math.floor((currentTokens * 100) / contextSize);
 }
 
-const elements = [`\ue370 ${modelDisplayName}`, `\uea83 ${currentDir}`];
+const elements = [renderClaudeBrandColor(`\ue370 ${modelDisplayName}`), `\uea83 ${currentDir}`];
 if (gitBranch) elements.push(`\ue725 ${gitBranch}`);
-if (contextInfo) elements.push(`\udb83\ude91 ${contextInfo}`);
+if (contextInfo) elements.push(
+  renderRatio(`\udb83\ude91 %d\%`, contextInfo)
+);
 
 const limitations: string[] = [];
 if (!isAwsBedrock) {
@@ -155,11 +173,14 @@ if (!isAwsBedrock) {
   const sevenDay = data.rate_limits?.seven_day;
   if (fiveHour) {
     limitations.push(
-      `\udb86\udd9f 5h: ${fiveHour.used_percentage}% (Reset at ${formatResetTime(fiveHour.resets_at)})`,
+      renderRatio(
+        `\udb86\udd9f 5h: %d\% (Reset at ${formatResetTime(fiveHour.resets_at)})`,
+        Math.floor(fiveHour.used_percentage)
+      )
     );
   }
   if (sevenDay) {
-    limitations.push(`\udb80\udcf0 7d: ${sevenDay.used_percentage}%`);
+    limitations.push(renderRatio(`\udb80\udcf0 7d: %d\%`, Math.floor(sevenDay.used_percentage)));
   }
 }
 

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -2,26 +2,12 @@
 
 import { format } from "node:util";
 import { execSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
 import path from "node:path";
 
 import chalk from "chalk";
 
 // NOTE: Set level 3 to affect colors in the statusline.
 chalk.level = 3;
-
-const DEBUG = process.env.STATUSLINE_DEBUG === "1";
-const LOG_FILE = process.env.STATUSLINE_LOG_FILE ?? "/tmp/statusline.log";
-
-function log(level: "INFO" | "ERROR", message: string): void {
-  if (!DEBUG) return;
-  const ts = new Date().toISOString();
-  try {
-    appendFileSync(LOG_FILE, `${ts} [${level}] ${message}\n`);
-  } catch {
-    // ログ書き込み失敗でstatuslineをクラッシュさせない
-  }
-}
 
 function renderClaudeBrandColor(msg: string) {
   return chalk.hex("#DE7356")(msg);
@@ -107,94 +93,95 @@ function formatResetTime(resetsAt: number): string {
   return `${hours}:${minutes}`;
 }
 
-let input: string;
-try {
-  input = await Bun.stdin.text();
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`statusline: failed to read stdin: ${message}\n`);
-  log("ERROR", `failed to read stdin: ${message}`);
-  process.stdout.write("🤖 Claude Code\n");
-  process.exit(1);
-}
+async function main() {
+  let input: string;
+  try {
+    input = await Bun.stdin.text();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`statusline: failed to read stdin: ${message}\n`);
+    process.stdout.write("🤖 Claude Code\n");
+    process.exit(1);
+  }
 
-let data: unknown;
-try {
-  data = JSON.parse(input);
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`statusline: JSON parse failed: ${message}\n`);
-  log("ERROR", `JSON parse failed: ${message}`);
-  process.exit(1);
-}
+  let data: unknown;
+  try {
+    data = JSON.parse(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`statusline: JSON parse failed: ${message}\n`);
+    process.exit(1);
+  }
 
-if (!isStatuslineInput(data)) {
-  process.stderr.write(
-    "statusline: invalid input: missing required fields (model.display_name, workspace.current_dir)\n",
-  );
-  log("ERROR", `invalid input shape: ${JSON.stringify(data)}`);
-  process.exit(1);
-}
-log("INFO", `stdin fields: ${Object.keys(data).join(", ")}`);
-
-const isAwsBedrock = data.model.id?.startsWith("arn:") ?? false;
-const modelDisplayName = isAwsBedrock
-  ? data.model.display_name.startsWith("arn:")
-    ? `${data.model.display_name.split("/").pop() ?? data.model.display_name} by AWS`
-    : `${data.model.display_name} by AWS`
-  : data.model.display_name;
-const currentDir = path.basename(data.workspace.current_dir);
-
-let gitBranch = "";
-try {
-  gitBranch = execSync("git branch --show-current", {
-    cwd: data.workspace.current_dir,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  }).trim();
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`statusline: git branch failed: ${message}\n`);
-  log("ERROR", `git branch failed: ${message}`);
-}
-
-let contextInfo = 0;
-const contextSize = data.context_window?.context_window_size;
-const currentUsage = data.context_window?.current_usage;
-if (currentUsage && contextSize && contextSize > 0) {
-  const currentTokens =
-    (currentUsage.input_tokens ?? 0) +
-    (currentUsage.cache_creation_input_tokens ?? 0) +
-    (currentUsage.cache_read_input_tokens ?? 0);
-  contextInfo = Math.floor((currentTokens * 100) / contextSize);
-}
-
-const elements = [renderClaudeBrandColor(`\ue370 ${modelDisplayName}`), renderSubText(`\uea83 ${currentDir}`)];
-if (gitBranch) elements.push(renderSubText(`\ue725 ${gitBranch}`));
-if (contextInfo) elements.push(
-  renderRatio(`\udb83\ude91 %d\%`, contextInfo)
-);
-
-const limitations: string[] = [];
-if (!isAwsBedrock) {
-  const fiveHour = data.rate_limits?.five_hour;
-  const sevenDay = data.rate_limits?.seven_day;
-  if (fiveHour) {
-    limitations.push(
-      renderRatio(
-        `\udb86\udd9f 5h: %d\% (Reset at ${formatResetTime(fiveHour.resets_at)})`,
-        Math.floor(fiveHour.used_percentage)
-      )
+  if (!isStatuslineInput(data)) {
+    process.stderr.write(
+      "statusline: invalid input: missing required fields (model.display_name, workspace.current_dir)\n",
     );
+    process.exit(1);
   }
-  if (sevenDay) {
-    limitations.push(renderRatio(`\udb80\udcf0 7d: %d\%`, Math.floor(sevenDay.used_percentage)));
+
+  const isAwsBedrock = data.model.id?.startsWith("arn:") ?? false;
+  const modelDisplayName = isAwsBedrock
+    ? data.model.display_name.startsWith("arn:")
+      ? `${data.model.display_name.split("/").pop() ?? data.model.display_name} by AWS`
+      : `${data.model.display_name} by AWS`
+    : data.model.display_name;
+  const currentDir = path.basename(data.workspace.current_dir);
+
+  let gitBranch = "";
+  try {
+    gitBranch = execSync("git branch --show-current", {
+      cwd: data.workspace.current_dir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`statusline: git branch failed: ${message}\n`);
   }
+
+  let contextInfo = 0;
+  const contextSize = data.context_window?.context_window_size;
+  const currentUsage = data.context_window?.current_usage;
+  if (currentUsage && contextSize && contextSize > 0) {
+    const currentTokens =
+      (currentUsage.input_tokens ?? 0) +
+      (currentUsage.cache_creation_input_tokens ?? 0) +
+      (currentUsage.cache_read_input_tokens ?? 0);
+    contextInfo = Math.floor((currentTokens * 100) / contextSize);
+  }
+
+  const elements = [
+    renderClaudeBrandColor(` ${modelDisplayName}`),
+    renderSubText(` ${currentDir}`),
+  ];
+  if (gitBranch) elements.push(renderSubText(` ${gitBranch}`));
+  if (contextInfo) elements.push(renderRatio(`󰺑 %d\%`, contextInfo));
+
+  const limitations: string[] = [];
+  if (!isAwsBedrock) {
+    const fiveHour = data.rate_limits?.five_hour;
+    const sevenDay = data.rate_limits?.seven_day;
+    if (fiveHour) {
+      limitations.push(
+        renderRatio(
+          `󱦟 5h: %d\% (Reset at ${formatResetTime(fiveHour.resets_at)})`,
+          Math.floor(fiveHour.used_percentage),
+        ),
+      );
+    }
+    if (sevenDay) {
+      limitations.push(
+        renderRatio(`󰃰 7d: %d\%`, Math.floor(sevenDay.used_percentage)),
+      );
+    }
+  }
+
+  const divider = renderDivider(" | ");
+  const output = elements.join(divider);
+  const limitationOutput = limitations.join(divider);
+  console.log(output);
+  if (limitations.length > 0) console.log(limitationOutput);
 }
 
-const divider = renderDivider(" | ");
-const output = elements.join(divider);
-const limitationOutput = limitations.join(divider);
-log("INFO", `output: ${output}`);
-console.log(output);
-if (limitations.length > 0) console.log(limitationOutput);
+main();

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -1,83 +1,138 @@
 #!/usr/bin/env bun
 
-import { execSync } from 'node:child_process';
-import path from 'node:path';
+import { execSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+
+const DEBUG = process.env.STATUSLINE_DEBUG === "1";
+const LOG_FILE = process.env.STATUSLINE_LOG_FILE ?? "/tmp/statusline.log";
+
+function log(level: "INFO" | "ERROR", message: string): void {
+  if (!DEBUG) return;
+  const ts = new Date().toISOString();
+  appendFileSync(LOG_FILE, `${ts} [${level}] ${message}\n`);
+}
 
 interface ContextWindow {
-    context_window_size?: number;
-    current_usage?: {
-        input_tokens?: number;
-        cache_creation_input_tokens?: number;
-        cache_read_input_tokens?: number;
-    };
+  context_window_size?: number;
+  current_usage?: {
+    input_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+interface RateLimit {
+  used_percentage: number;
+  resets_at: number;
 }
 
 interface StatuslineInput {
-    model: { display_name: string };
-    workspace: { current_dir: string };
-    context_window?: ContextWindow;
+  model: { id?: string; display_name: string };
+  workspace: { current_dir: string };
+  context_window?: ContextWindow;
+  rate_limits?: {
+    five_hour?: RateLimit;
+    seven_day?: RateLimit;
+  };
 }
 
 function isStatuslineInput(value: unknown): value is StatuslineInput {
-    if (typeof value !== 'object' || value === null) return false;
-    const v = value as Record<string, unknown>;
-    if (typeof (v.model as Record<string, unknown>)?.display_name !== 'string') return false;
-    if (typeof (v.workspace as Record<string, unknown>)?.current_dir !== 'string') return false;
-    return true;
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof (v.model as Record<string, unknown>)?.display_name !== "string")
+    return false;
+  if (typeof (v.workspace as Record<string, unknown>)?.current_dir !== "string")
+    return false;
+  return true;
+}
+
+function formatResetTime(resetsAt: number): string {
+  const date = new Date(resetsAt * 1000);
+  const hours = date.getHours().toString().padStart(2, "0");
+  const minutes = date.getMinutes().toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
 }
 
 let input: string;
 try {
-    input = await Bun.stdin.text();
+  input = await Bun.stdin.text();
+  log("INFO", `raw stdin: ${input}`);
 } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`statusline: failed to read stdin: ${message}\n`);
-    process.stdout.write('🤖 Claude Code\n');
-    process.exit(1);
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`statusline: failed to read stdin: ${message}\n`);
+  log("ERROR", `failed to read stdin: ${message}`);
+  process.stdout.write("🤖 Claude Code\n");
+  process.exit(1);
 }
 
 let data: unknown;
 try {
-    data = JSON.parse(input);
+  data = JSON.parse(input);
 } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`statusline: JSON parse failed: ${message}\n`);
-    process.exit(1);
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`statusline: JSON parse failed: ${message}\n`);
+  log("ERROR", `JSON parse failed: ${message}`);
+  process.exit(1);
 }
 
 if (!isStatuslineInput(data)) {
-    process.stderr.write('statusline: invalid input: missing required fields (model.display_name, workspace.current_dir)\n');
-    process.exit(1);
+  process.stderr.write(
+    "statusline: invalid input: missing required fields (model.display_name, workspace.current_dir)\n",
+  );
+  log("ERROR", `invalid input shape: ${JSON.stringify(data)}`);
+  process.exit(1);
 }
 
-const model = data.model.display_name;
+const isAwsBedrock = data.model.id?.startsWith("arn:") ?? false;
+const modelDisplayName = isAwsBedrock
+  ? data.model.display_name.startsWith("arn:")
+    ? data.model.display_name
+    : `${data.model.display_name} by AWS`
+  : data.model.display_name;
 const currentDir = path.basename(data.workspace.current_dir);
 
-let gitBranch = '';
+let gitBranch = "";
 try {
-    gitBranch = execSync('git branch --show-current', {
-        cwd: data.workspace.current_dir,
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+  gitBranch = execSync("git branch --show-current", {
+    cwd: data.workspace.current_dir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
 } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`statusline: git branch failed: ${message}\n`);
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`statusline: git branch failed: ${message}\n`);
+  log("ERROR", `git branch failed: ${message}`);
 }
 
-let contextInfo = '';
+let contextInfo = "";
 const contextSize = data.context_window?.context_window_size;
 const currentUsage = data.context_window?.current_usage;
 if (currentUsage && contextSize && contextSize > 0) {
-    const currentTokens =
-        (currentUsage.input_tokens ?? 0) +
-        (currentUsage.cache_creation_input_tokens ?? 0) +
-        (currentUsage.cache_read_input_tokens ?? 0);
-    contextInfo = `${Math.floor((currentTokens * 100) / contextSize)}%`;
+  const currentTokens =
+    (currentUsage.input_tokens ?? 0) +
+    (currentUsage.cache_creation_input_tokens ?? 0) +
+    (currentUsage.cache_read_input_tokens ?? 0);
+  contextInfo = `${Math.floor((currentTokens * 100) / contextSize)}%`;
 }
 
-const elements = [`🤖 ${model}`, `📁 ${currentDir}`];
+const elements = [`🤖 ${modelDisplayName}`, `📁 ${currentDir}`];
 if (gitBranch) elements.push(` ${gitBranch}`);
 if (contextInfo) elements.push(`📊 ${contextInfo}`);
 
-console.log(elements.join(' | '));
+if (!isAwsBedrock) {
+  const fiveHour = data.rate_limits?.five_hour;
+  const sevenDay = data.rate_limits?.seven_day;
+  if (fiveHour) {
+    elements.push(
+      `5-Hour limit: ${fiveHour.used_percentage}% Reset in ${formatResetTime(fiveHour.resets_at)}`,
+    );
+  }
+  if (sevenDay) {
+    elements.push(`Weekly limit: ${sevenDay.used_percentage}%`);
+  }
+}
+
+const output = elements.join(" | ");
+log("INFO", `output: ${output}`);
+console.log(output);

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -28,9 +28,17 @@ function renderClaudeBrandColor(msg: string) {
 }
 
 function renderRatio(msg: string, ratio: number) {
-  if (ratio < 50) return chalk.reset(format(msg, ratio));
+  if (ratio < 50) return chalk.hex("cccccc")(format(msg, ratio));
   if (ratio < 75) return chalk.yellow(format(msg, ratio));
   return chalk.red(format(msg, ratio));
+}
+
+function renderSubText(msg: string) {
+  return chalk.hex("9c9c9c")(msg);
+}
+
+function renderDivider(msg: string) {
+  return chalk.hex("5c5c5c")(msg);
 }
 
 interface ContextWindow {
@@ -161,8 +169,8 @@ if (currentUsage && contextSize && contextSize > 0) {
   contextInfo = Math.floor((currentTokens * 100) / contextSize);
 }
 
-const elements = [renderClaudeBrandColor(`\ue370 ${modelDisplayName}`), `\uea83 ${currentDir}`];
-if (gitBranch) elements.push(`\ue725 ${gitBranch}`);
+const elements = [renderClaudeBrandColor(`\ue370 ${modelDisplayName}`), renderSubText(`\uea83 ${currentDir}`)];
+if (gitBranch) elements.push(renderSubText(`\ue725 ${gitBranch}`));
 if (contextInfo) elements.push(
   renderRatio(`\udb83\ude91 %d\%`, contextInfo)
 );
@@ -184,8 +192,9 @@ if (!isAwsBedrock) {
   }
 }
 
-const output = elements.join(" | ");
-const limitationOutput = limitations.join(" | ");
+const divider = renderDivider(" | ");
+const output = elements.join(divider);
+const limitationOutput = limitations.join(divider);
 log("INFO", `output: ${output}`);
 console.log(output);
 if (limitations.length > 0) console.log(limitationOutput);

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -163,10 +163,10 @@ async function main() {
   const contextInfo = calcContextUsage(data.context_window);
 
   const elements = [
-    renderClaudeBrandColor(` ${modelDisplayName}`),
-    renderSubText(` ${currentDir}`),
+    renderClaudeBrandColor(` ${modelDisplayName}`),
+    renderSubText(` ${currentDir}`),
   ];
-  if (gitBranch) elements.push(renderSubText(` ${gitBranch}`));
+  if (gitBranch) elements.push(renderSubText(` ${gitBranch}`));
   if (contextInfo) elements.push(renderRatio(`󰺑 %d\%`, contextInfo));
 
   const limitations: string[] = [];

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -116,23 +116,26 @@ if (currentUsage && contextSize && contextSize > 0) {
   contextInfo = `${Math.floor((currentTokens * 100) / contextSize)}%`;
 }
 
-const elements = [`🤖 ${modelDisplayName}`, `📁 ${currentDir}`];
-if (gitBranch) elements.push(` ${gitBranch}`);
-if (contextInfo) elements.push(`📊 ${contextInfo}`);
+const elements = [`\ue370 ${modelDisplayName}`, `\uea83 ${currentDir}`];
+if (gitBranch) elements.push(`\ue725 ${gitBranch}`);
+if (contextInfo) elements.push(`\udb83\ude91 ${contextInfo}`);
 
+const limitations = [];
 if (!isAwsBedrock) {
   const fiveHour = data.rate_limits?.five_hour;
   const sevenDay = data.rate_limits?.seven_day;
   if (fiveHour) {
-    elements.push(
-      `5-Hour limit: ${fiveHour.used_percentage}% Reset in ${formatResetTime(fiveHour.resets_at)}`,
+    limitations.push(
+      `\udb86\udd9f 5h: ${fiveHour.used_percentage}% (Reset at ${formatResetTime(fiveHour.resets_at)})`,
     );
   }
   if (sevenDay) {
-    elements.push(`Weekly limit: ${sevenDay.used_percentage}%`);
+    limitations.push(`\udb80\udcf0 7d: ${sevenDay.used_percentage}%`);
   }
 }
 
 const output = elements.join(" | ");
+const limitationOutput = limitations.join(" | ");
 log("INFO", `output: ${output}`);
 console.log(output);
+if (limitations.length > 0) console.log(limitationOutput);

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -51,7 +51,7 @@ interface StatuslineInput {
   };
 }
 
-function isRateLimit(v: unknown): v is RateLimit {
+export function isRateLimit(v: unknown): v is RateLimit {
   if (typeof v !== "object" || v === null) return false;
   const r = v as Record<string, unknown>;
   return (
@@ -61,7 +61,7 @@ function isRateLimit(v: unknown): v is RateLimit {
   );
 }
 
-function isStatuslineInput(value: unknown): value is StatuslineInput {
+export function isStatuslineInput(value: unknown): value is StatuslineInput {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   if (typeof (v.model as Record<string, unknown>)?.display_name !== "string")
@@ -85,12 +85,48 @@ function isStatuslineInput(value: unknown): value is StatuslineInput {
   return true;
 }
 
-function formatResetTime(resetsAt: number): string {
+export function formatResetTime(resetsAt: number): string {
   if (!Number.isFinite(resetsAt) || resetsAt <= 0) return "??:??";
   const date = new Date(resetsAt * 1000);
   const hours = date.getHours().toString().padStart(2, "0");
   const minutes = date.getMinutes().toString().padStart(2, "0");
   return `${hours}:${minutes}`;
+}
+
+function extractModelName(model: StatuslineInput["model"]): string {
+  if (!(model.id?.startsWith("arn:") ?? false)) return model.display_name;
+  return model.display_name.startsWith("arn:")
+    ? `${model.display_name.split("/").pop() ?? model.display_name} by AWS`
+    : `${model.display_name} by AWS`;
+}
+
+function extractCurrentDir(workspace: StatuslineInput["workspace"]): string {
+  return path.basename(workspace.current_dir);
+}
+
+function getBranchName(cwd: string): string {
+  try {
+    return execSync("git branch --show-current", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`statusline: git branch failed: ${message}\n`);
+    return "";
+  }
+}
+
+function calcContextUsage(contextWindow: ContextWindow | undefined): number {
+  const contextSize = contextWindow?.context_window_size;
+  const currentUsage = contextWindow?.current_usage;
+  if (!currentUsage || !contextSize || contextSize <= 0) return 0;
+  const currentTokens =
+    (currentUsage.input_tokens ?? 0) +
+    (currentUsage.cache_creation_input_tokens ?? 0) +
+    (currentUsage.cache_read_input_tokens ?? 0);
+  return Math.floor((currentTokens * 100) / contextSize);
 }
 
 async function main() {
@@ -121,41 +157,16 @@ async function main() {
   }
 
   const isAwsBedrock = data.model.id?.startsWith("arn:") ?? false;
-  const modelDisplayName = isAwsBedrock
-    ? data.model.display_name.startsWith("arn:")
-      ? `${data.model.display_name.split("/").pop() ?? data.model.display_name} by AWS`
-      : `${data.model.display_name} by AWS`
-    : data.model.display_name;
-  const currentDir = path.basename(data.workspace.current_dir);
-
-  let gitBranch = "";
-  try {
-    gitBranch = execSync("git branch --show-current", {
-      cwd: data.workspace.current_dir,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`statusline: git branch failed: ${message}\n`);
-  }
-
-  let contextInfo = 0;
-  const contextSize = data.context_window?.context_window_size;
-  const currentUsage = data.context_window?.current_usage;
-  if (currentUsage && contextSize && contextSize > 0) {
-    const currentTokens =
-      (currentUsage.input_tokens ?? 0) +
-      (currentUsage.cache_creation_input_tokens ?? 0) +
-      (currentUsage.cache_read_input_tokens ?? 0);
-    contextInfo = Math.floor((currentTokens * 100) / contextSize);
-  }
+  const modelDisplayName = extractModelName(data.model);
+  const currentDir = extractCurrentDir(data.workspace);
+  const gitBranch = getBranchName(data.workspace.current_dir);
+  const contextInfo = calcContextUsage(data.context_window);
 
   const elements = [
-    renderClaudeBrandColor(` ${modelDisplayName}`),
-    renderSubText(` ${currentDir}`),
+    renderClaudeBrandColor(` ${modelDisplayName}`),
+    renderSubText(` ${currentDir}`),
   ];
-  if (gitBranch) elements.push(renderSubText(` ${gitBranch}`));
+  if (gitBranch) elements.push(renderSubText(` ${gitBranch}`));
   if (contextInfo) elements.push(renderRatio(`󰺑 %d\%`, contextInfo));
 
   const limitations: string[] = [];
@@ -184,4 +195,6 @@ async function main() {
   if (limitations.length > 0) console.log(limitationOutput);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -10,7 +10,11 @@ const LOG_FILE = process.env.STATUSLINE_LOG_FILE ?? "/tmp/statusline.log";
 function log(level: "INFO" | "ERROR", message: string): void {
   if (!DEBUG) return;
   const ts = new Date().toISOString();
-  appendFileSync(LOG_FILE, `${ts} [${level}] ${message}\n`);
+  try {
+    appendFileSync(LOG_FILE, `${ts} [${level}] ${message}\n`);
+  } catch {
+    // ログ書き込み失敗でstatuslineをクラッシュさせない
+  }
 }
 
 interface ContextWindow {
@@ -37,6 +41,16 @@ interface StatuslineInput {
   };
 }
 
+function isRateLimit(v: unknown): v is RateLimit {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.used_percentage === "number" &&
+    typeof r.resets_at === "number" &&
+    Number.isFinite(r.resets_at)
+  );
+}
+
 function isStatuslineInput(value: unknown): value is StatuslineInput {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
@@ -44,10 +58,17 @@ function isStatuslineInput(value: unknown): value is StatuslineInput {
     return false;
   if (typeof (v.workspace as Record<string, unknown>)?.current_dir !== "string")
     return false;
+  const rl = v.rate_limits;
+  if (rl !== undefined && typeof rl === "object" && rl !== null) {
+    const rateLimits = rl as Record<string, unknown>;
+    if (rateLimits.five_hour !== undefined && !isRateLimit(rateLimits.five_hour)) return false;
+    if (rateLimits.seven_day !== undefined && !isRateLimit(rateLimits.seven_day)) return false;
+  }
   return true;
 }
 
 function formatResetTime(resetsAt: number): string {
+  if (!Number.isFinite(resetsAt) || resetsAt <= 0) return "??:??";
   const date = new Date(resetsAt * 1000);
   const hours = date.getHours().toString().padStart(2, "0");
   const minutes = date.getMinutes().toString().padStart(2, "0");
@@ -57,7 +78,6 @@ function formatResetTime(resetsAt: number): string {
 let input: string;
 try {
   input = await Bun.stdin.text();
-  log("INFO", `raw stdin: ${input}`);
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`statusline: failed to read stdin: ${message}\n`);
@@ -83,11 +103,12 @@ if (!isStatuslineInput(data)) {
   log("ERROR", `invalid input shape: ${JSON.stringify(data)}`);
   process.exit(1);
 }
+log("INFO", `stdin fields: ${Object.keys(data as Record<string, unknown>).join(", ")}`);
 
 const isAwsBedrock = data.model.id?.startsWith("arn:") ?? false;
 const modelDisplayName = isAwsBedrock
   ? data.model.display_name.startsWith("arn:")
-    ? data.model.display_name
+    ? `${data.model.display_name.split("/").pop() ?? data.model.display_name} by AWS`
     : `${data.model.display_name} by AWS`
   : data.model.display_name;
 const currentDir = path.basename(data.workspace.current_dir);
@@ -120,7 +141,7 @@ const elements = [`\ue370 ${modelDisplayName}`, `\uea83 ${currentDir}`];
 if (gitBranch) elements.push(`\ue725 ${gitBranch}`);
 if (contextInfo) elements.push(`\udb83\ude91 ${contextInfo}`);
 
-const limitations = [];
+const limitations: string[] = [];
 if (!isAwsBedrock) {
   const fiveHour = data.rate_limits?.five_hour;
   const sevenDay = data.rate_limits?.seven_day;

--- a/claude/statusline.ts
+++ b/claude/statusline.ts
@@ -93,7 +93,7 @@ export function formatResetTime(resetsAt: number): string {
   return `${hours}:${minutes}`;
 }
 
-function extractModelName(model: StatuslineInput["model"]): string {
+export function extractModelName(model: StatuslineInput["model"]): string {
   if (!(model.id?.startsWith("arn:") ?? false)) return model.display_name;
   return model.display_name.startsWith("arn:")
     ? `${model.display_name.split("/").pop() ?? model.display_name} by AWS`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
+  "scripts": {
+    "typecheck": "tsc -p . --noEmit"
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^6.0.3"
+  },
+  "dependencies": {
+    "chalk": "^5.6.2"
   }
 }


### PR DESCRIPTION
## Summary

- Show 5-hour and weekly rate limit usage in the status line for Claude Pro users
- Detect AWS Bedrock backend via ARN model ID and append suffix to model name
- Replace emoji with Nerd Font icons throughout the status line
- Output rate limit info as a separate second line

## Why

The status line previously showed only model name, directory, git branch, and context usage. Adding rate limit visibility helps avoid hitting usage limits unexpectedly during a session. Bedrock users need a visual indicator that they are on a different backend with no usage cap.

## Changes

- Add `RateLimit` interface and `rate_limits` field to `StatuslineInput`
- Add `model.id` to `StatuslineInput` to detect Bedrock (ARN prefix)
- Add `formatResetTime()` to convert Unix timestamp to local `HH:MM`
- Append `by AWS` to model name when using a non-ARN display name on Bedrock
- Collect rate limit segments into a `limitations` array and print as a second line
- Swap emoji for Nerd Font Unicode codepoints for icons

## Test Plan

- [x] Pipe Claude Pro sample JSON and verify rate limit segments appear on second line
- [x] Pipe AWS Bedrock sample JSON and verify `by AWS` suffix and no rate limit output
- [x] Verify missing `rate_limits` field produces no extra output line


<img width="766" height="430" alt="image" src="https://github.com/user-attachments/assets/748d792b-7c4c-4612-b36a-910c82507b5a" />

```bash
echo "=== 30% === "
bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":30000}},"rate_limits":{"five_hour":{"used_percentage":30,"resets_at":1746700000},"seven_day":{"used_percentage":30,"resets_at":1746700000}}}'
echo ""

echo "=== 60% ==="
bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":60000}},"rate_limits":{"five_hour":{"used_percentage":60,"resets_at":1746700000},"seven_day":{"used_percentage":60,"resets_at":1746700000}}}'
echo ""

echo "=== 80% ==="
bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":80000}},"rate_limits":{"five_hour":{"used_percentage":80,"resets_at":1746700000},"seven_day":{"used_percentage":80,"resets_at":1746700000}}}'
echo ""

echo "=== display_name includes arn ==="
bun run claude/statusline.ts <<< '{"model":{"id":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0","display_name":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"}}'
echo ""

echo "=== model id includes but display_name is friendly ==="
bun run claude/statusline.ts <<< '{"model":{"id":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0","display_name":"Claude 3.5 Sonnet"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"}}'
echo ""

echo "=== by AWS and context usage included ==="
bun run claude/statusline.ts <<< '{"model":{"id":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0","display_name":"Claude 3.5 Sonnet"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":80000}},"rate_limits":{"five_hour":{"used_percentage":80,"resets_at":1746700000}}}'
echo ""

```