### PR TITLE
chore: configure Claude Code terminal and editor settings

### DIFF
--- a/alacritty/.config/alacritty/alacritty.toml
+++ b/alacritty/.config/alacritty/alacritty.toml
@@ -61,3 +61,8 @@ x = 4
 y = 0
 
 [mouse]
+
+[[keyboard.bindings]]
+key = "Return"
+mods = "Shift"
+chars = "\u001B\r"

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -45,8 +45,6 @@ async function main() {
     input = await Bun.stdin.text();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`notification: failed to read stdin: ${message}\n`);
-    process.stdout.write("🤖 Claude Code\n");
     process.exit(1);
   }
 
@@ -55,14 +53,10 @@ async function main() {
     data = JSON.parse(input);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`notification: JSON parse failed: ${message}\n`);
     process.exit(1);
   }
 
   if (!isValidNotificationInput(data)) {
-    process.stderr.write(
-      "notification: invalid input: missing required fields\n",
-    );
     process.exit(1);
   }
 
@@ -80,11 +74,14 @@ async function main() {
     ]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`notification: failed to run notification: ${message}\n`);
     process.exit(1);
   }
 }
 
 if (import.meta.main) {
-  main().catch((error) => console.error(error));
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`notification: unexpected error: ${message}\n`);
+    process.exit(1);
+  });
 }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -30,8 +30,7 @@ function isValidNotificationInput(input: unknown): input is NotificationInput {
   const obj = input as Record<string, unknown>;
   return (
     typeof obj.notification_type === "string" &&
-    typeof obj.message === "string" &&
-    typeof obj.title === "string"
+    typeof obj.message === "string"
   );
 }
 
@@ -68,7 +67,7 @@ async function main() {
 
   try {
     // argv[0]=message body, argv[1]=subtitle (title is hardcoded to "Claude Code")
-    await execFileAsync("osascript", ["-e", script, "--", data.message, data.title]);
+    await execFileAsync("osascript", ["-e", script, "--", data.message, data.title || "Permission needed"]);
   } catch (error) {
     process.exit(1);
   }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -75,7 +75,7 @@ async function sendNotificationAlert(data: NotificationInput) {
     "--",
     data.message,
     subtitle,
-    "Glass",
+    "Purr",
   ]);
 }
 

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -2,7 +2,6 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { appendFileSync } from "node:fs";
 
 const execFileAsync = promisify(execFile);
 
@@ -31,6 +30,11 @@ interface NotificationInput extends BaseInput {
   title?: string;
 }
 
+interface StopInput extends BaseInput {
+  stop_hook_active: boolean;
+  last_assistant_message: string;
+}
+
 function isValidNotificationInput(input: unknown): input is NotificationInput {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     return false;
@@ -41,46 +45,79 @@ function isValidNotificationInput(input: unknown): input is NotificationInput {
   );
 }
 
+function isValidStopInput(input: unknown): input is StopInput {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return false;
+  }
+  const obj = input as Record<string, unknown>;
+  return (
+    typeof obj.stop_hook_active === "boolean" &&
+    typeof obj.last_assistant_message === "string"
+  );
+}
+
 function isIdlePrompt(data: NotificationInput) {
   return data.notification_type === "idle_prompt";
 }
 
+const OSASCRIPT_DISPLAY_NOTIFICATION = `
+  on run argv
+    display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv) sound name (item 3 of argv)
+  end run
+`;
+
+async function sendNotificationAlert(data: NotificationInput) {
+  const subtitle =
+    data.title || capitalize(data.notification_type.replace("_", " "));
+  await execFileAsync("osascript", [
+    "-e",
+    OSASCRIPT_DISPLAY_NOTIFICATION,
+    "--",
+    data.message,
+    subtitle,
+    "Glass",
+  ]);
+}
+
+async function sendStopAlert(data: StopInput) {
+  const message = data.last_assistant_message || "Task completed";
+  await execFileAsync("osascript", [
+    "-e",
+    OSASCRIPT_DISPLAY_NOTIFICATION,
+    "--",
+    message,
+    "Claude stopped",
+    "Blow",
+  ]);
+}
+
 async function main() {
+  const mode = (process.argv[2] ?? "notification") as "notification" | "stop";
+
   let input: string;
   try {
     input = await Bun.stdin.text();
-    // appendFileSync("/tmp/claude-notification-log.txt", input + "\n", {
-    //   encoding: "utf-8",
-    // });
-  } catch (error) {
+  } catch {
     process.exit(1);
   }
 
   let data: unknown;
   try {
     data = JSON.parse(input);
-  } catch (error) {
+  } catch {
     process.exit(1);
   }
-
-  if (!isValidNotificationInput(data)) {
-    process.exit(1);
-  }
-
-  if (isIdlePrompt(data)) return;
-
-  const script = `
-    on run argv
-      display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv) sound name "Glass"
-    end run
-  `;
 
   try {
-    // argv[0]=message body, argv[1]=subtitle (title is hardcoded to "Claude Code")
-    const title =
-      data.title || capitalize(data.notification_type.replace("_", " "));
-    await execFileAsync("osascript", ["-e", script, "--", data.message, title]);
-  } catch (error) {
+    if (mode === "stop") {
+      if (!isValidStopInput(data)) process.exit(1);
+      await sendStopAlert(data);
+    } else {
+      if (!isValidNotificationInput(data)) process.exit(1);
+      if (isIdlePrompt(data)) return;
+      await sendNotificationAlert(data);
+    }
+  } catch {
     process.exit(1);
   }
 }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -1,9 +1,40 @@
 #!/usr/bin/env bun
 
 import { execFile } from "node:child_process";
+import { mkdirSync, appendFileSync } from "node:fs";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+const LOG_DIR = `${process.env.HOME}/.claude/logs`;
+const LOG_FILE = `${LOG_DIR}/${process.env.USER}-hook-notification.log`;
+
+function writeLog(message: string) {
+  const timestamp = new Date().toISOString();
+  try {
+    mkdirSync(LOG_DIR, { recursive: true });
+    appendFileSync(LOG_FILE, `${timestamp} ${message}\n`);
+  } catch {
+    // log write failure is non-fatal
+  }
+}
+
+const OSASCRIPT_DISPLAY_NOTIFICATION = `
+  on run argv
+    display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv) sound name (item 3 of argv)
+  end run
+`;
+
+async function notifyError(message: string) {
+  await execFileAsync("osascript", [
+    "-e",
+    OSASCRIPT_DISPLAY_NOTIFICATION,
+    "--",
+    message,
+    "Hook Error",
+    "Pop",
+  ]).catch(() => {});
+}
 
 function capitalize(msg: string) {
   return msg.charAt(0).toUpperCase() + msg.substring(1);
@@ -60,12 +91,6 @@ function isIdlePrompt(data: NotificationInput) {
   return data.notification_type === "idle_prompt";
 }
 
-const OSASCRIPT_DISPLAY_NOTIFICATION = `
-  on run argv
-    display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv) sound name (item 3 of argv)
-  end run
-`;
-
 async function sendNotificationAlert(data: NotificationInput) {
   const subtitle =
     data.title || capitalize(data.notification_type.replaceAll("_", " "));
@@ -98,35 +123,51 @@ async function main() {
   let input: string;
   try {
     input = await Bun.stdin.text();
-  } catch {
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    writeLog(`[error] failed to read stdin: ${msg}`);
+    await notifyError(`Failed to read stdin: ${msg}`);
     process.exit(1);
   }
 
   let data: unknown;
   try {
     data = JSON.parse(input);
-  } catch {
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    writeLog(`[error] failed to parse JSON: ${msg}`);
+    await notifyError(`Failed to parse JSON: ${msg}`);
     process.exit(1);
   }
 
   try {
     if (mode === "stop") {
-      if (!isValidStopInput(data)) process.exit(1);
+      if (!isValidStopInput(data)) {
+        writeLog("[error] invalid stop input");
+        process.exit(1);
+      }
       await sendStopAlert(data);
     } else {
-      if (!isValidNotificationInput(data)) process.exit(1);
+      if (!isValidNotificationInput(data)) {
+        writeLog("[error] invalid notification input");
+        process.exit(1);
+      }
       if (isIdlePrompt(data)) return;
       await sendNotificationAlert(data);
     }
-  } catch {
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    writeLog(`[error] failed to send notification: ${msg}`);
+    await notifyError(`Failed to send notification: ${msg}`);
     process.exit(1);
   }
 }
 
 if (import.meta.main) {
-  main().catch((error) => {
+  main().catch(async (error) => {
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`notification: unexpected error: ${message}\n`);
+    writeLog(`[error] unexpected error: ${message}`);
+    await notifyError(`Unexpected error: ${message}`);
     process.exit(1);
   });
 }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+
+import { format } from "node:util";
+import { exec } from "node:child_process";
+
+const SOUND = "Glass";
+
+interface BaseInput {
+  type: "command" | "http" | "mcp_tool" | "prompt" | "agent";
+  if: string;
+  timeout: number;
+  statusMessage: string;
+  once: boolean;
+}
+
+interface NotificationInput extends BaseInput {
+  hook_event_name: "Notification";
+  notification_type: string;
+  message: string;
+  title: string;
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+}
+
+function isValidNotificationInput(input: unknown): input is NotificationInput {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return false;
+  }
+  const obj = input as Record<string, unknown>;
+  return (
+    typeof obj.notification_type === "string" &&
+    typeof obj.message === "string" &&
+    typeof obj.title === "string"
+  );
+}
+
+function isIdlePrompt(data: NotificationInput) {
+  return data.notification_type === "idle_prompt";
+}
+
+async function main() {
+  let input: string;
+  try {
+    input = await Bun.stdin.text();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`notification: failed to read stdin: ${message}\n`);
+    process.stdout.write("🤖 Claude Code\n");
+    process.exit(1);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`notification: JSON parse failed: ${message}\n`);
+    process.exit(1);
+  }
+
+  if (!isValidNotificationInput(data)) {
+    process.stderr.write(
+      "notification: invalid input: missing required fields\n",
+    );
+    process.exit(1);
+  }
+
+  if (isIdlePrompt(data)) return;
+
+  try {
+    const command = format(
+      "osascript -e 'display notification \"%s\" with title \"Claude Code\" subtitle \"%s\"'",
+      data.message,
+      data.title
+    );
+    exec(command);
+    exec(format("afplay /System/Library/Sounds/%s.aiff", SOUND));
+  } catch (error) {
+    process.stderr.write(
+      "notification: failed to run osascript\n",
+    );
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => console.error(error));
+}

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -69,9 +69,8 @@ async function main() {
   `;
 
   try {
-    await Promise.all([
-      execFileAsync("osascript", ["-e", script, "--", data.message, data.title]),
-    ]);
+    // argv[0]=message body, argv[1]=subtitle (title is hardcoded to "Claude Code")
+    await execFileAsync("osascript", ["-e", script, "--", data.message, data.title]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.exit(1);

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -68,7 +68,7 @@ const OSASCRIPT_DISPLAY_NOTIFICATION = `
 
 async function sendNotificationAlert(data: NotificationInput) {
   const subtitle =
-    data.title || capitalize(data.notification_type.replace("_", " "));
+    data.title || capitalize(data.notification_type.replaceAll("_", " "));
   await execFileAsync("osascript", [
     "-e",
     OSASCRIPT_DISPLAY_NOTIFICATION,
@@ -80,6 +80,7 @@ async function sendNotificationAlert(data: NotificationInput) {
 }
 
 async function sendStopAlert(data: StopInput) {
+  if (data.stop_hook_active) return;
   const message = data.last_assistant_message || "Task completed";
   await execFileAsync("osascript", [
     "-e",

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -2,20 +2,22 @@
 
 import { execFile } from "node:child_process";
 import { mkdirSync, appendFileSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-const LOG_DIR = `${process.env.HOME}/.claude/logs`;
-const LOG_FILE = `${LOG_DIR}/${process.env.USER}-hook-notification.log`;
+const LOG_DIR = `${homedir()}/.claude/logs`;
+const LOG_FILE = `${LOG_DIR}/${userInfo().username}-hook-notification.log`;
 
 function writeLog(message: string) {
   const timestamp = new Date().toISOString();
   try {
     mkdirSync(LOG_DIR, { recursive: true });
     appendFileSync(LOG_FILE, `${timestamp} ${message}\n`);
-  } catch {
-    // log write failure is non-fatal
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`[notification] writeLog failed: ${msg}\n`);
   }
 }
 
@@ -26,6 +28,7 @@ const OSASCRIPT_DISPLAY_NOTIFICATION = `
 `;
 
 async function notifyError(message: string) {
+  if (process.env.CLAUDE_HOOK_TEST) return;
   await execFileAsync("osascript", [
     "-e",
     OSASCRIPT_DISPLAY_NOTIFICATION,
@@ -33,7 +36,10 @@ async function notifyError(message: string) {
     message,
     "Hook Error",
     "Pop",
-  ]).catch(() => {});
+  ]).catch((e: unknown) => {
+    const msg = e instanceof Error ? e.message : String(e);
+    writeLog(`[error] notifyError failed: ${msg}`);
+  });
 }
 
 function capitalize(msg: string) {
@@ -144,12 +150,14 @@ async function main() {
     if (mode === "stop") {
       if (!isValidStopInput(data)) {
         writeLog("[error] invalid stop input");
+        await notifyError("Invalid stop input");
         process.exit(1);
       }
       await sendStopAlert(data);
     } else {
       if (!isValidNotificationInput(data)) {
         writeLog("[error] invalid notification input");
+        await notifyError("Invalid notification input");
         process.exit(1);
       }
       if (isIdlePrompt(data)) return;
@@ -164,10 +172,10 @@ async function main() {
 }
 
 if (import.meta.main) {
-  main().catch(async (error) => {
+  main().catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     writeLog(`[error] unexpected error: ${message}`);
-    await notifyError(`Unexpected error: ${message}`);
+    process.stderr.write(`[notification] FATAL: ${message}\n`);
     process.exit(1);
   });
 }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -2,25 +2,33 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { appendFileSync } from "node:fs";
 
 const execFileAsync = promisify(execFile);
 
-interface BaseInput {
-  type: "command" | "http" | "mcp_tool" | "prompt" | "agent";
-  if: string;
-  timeout: number;
-  statusMessage: string;
-  once: boolean;
+function capitalize(msg: string) {
+  return msg.charAt(0).toUpperCase() + msg.substring(1);
 }
 
-interface NotificationInput extends BaseInput {
-  hook_event_name: "Notification";
-  notification_type: string;
-  message: string;
-  title: string;
+interface BaseInput {
   session_id: string;
   transcript_path: string;
   cwd: string;
+  permission_mode:
+    | "default"
+    | "plan"
+    | "acceptEdits"
+    | "auto"
+    | "dontAsk"
+    | "bypassPermissions";
+  effort: "low" | "medium" | "high" | "xhigh" | "max";
+  hook_event_name: string;
+}
+
+interface NotificationInput extends BaseInput {
+  notification_type: string;
+  message: string;
+  title?: string;
 }
 
 function isValidNotificationInput(input: unknown): input is NotificationInput {
@@ -29,8 +37,7 @@ function isValidNotificationInput(input: unknown): input is NotificationInput {
   }
   const obj = input as Record<string, unknown>;
   return (
-    typeof obj.notification_type === "string" &&
-    typeof obj.message === "string"
+    typeof obj.notification_type === "string" && typeof obj.message === "string"
   );
 }
 
@@ -42,6 +49,9 @@ async function main() {
   let input: string;
   try {
     input = await Bun.stdin.text();
+    // appendFileSync("/tmp/claude-notification-log.txt", input + "\n", {
+    //   encoding: "utf-8",
+    // });
   } catch (error) {
     process.exit(1);
   }
@@ -61,13 +71,15 @@ async function main() {
 
   const script = `
     on run argv
-      display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv)
+      display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv) sound name "Glass"
     end run
   `;
 
   try {
     // argv[0]=message body, argv[1]=subtitle (title is hardcoded to "Claude Code")
-    await execFileAsync("osascript", ["-e", script, "--", data.message, data.title || "Permission needed"]);
+    const title =
+      data.title || capitalize(data.notification_type.replace("_", " "));
+    await execFileAsync("osascript", ["-e", script, "--", data.message, title]);
   } catch (error) {
     process.exit(1);
   }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 
-import { format } from "node:util";
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 const SOUND = "Glass";
 
@@ -68,18 +70,20 @@ async function main() {
 
   if (isIdlePrompt(data)) return;
 
+  const script = `
+    on run argv
+      display notification (item 1 of argv) with title "Claude Code" subtitle (item 2 of argv)
+    end run
+  `;
+
   try {
-    const command = format(
-      "osascript -e 'display notification \"%s\" with title \"Claude Code\" subtitle \"%s\"'",
-      data.message,
-      data.title
-    );
-    exec(command);
-    exec(format("afplay /System/Library/Sounds/%s.aiff", SOUND));
+    await Promise.all([
+      execFileAsync("osascript", ["-e", script, "--", data.message, data.title]),
+      execFileAsync("afplay", [`/System/Library/Sounds/${SOUND}.aiff`]),
+    ]);
   } catch (error) {
-    process.stderr.write(
-      "notification: failed to run osascript\n",
-    );
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`notification: failed to run notification: ${message}\n`);
     process.exit(1);
   }
 }

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -5,8 +5,6 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-const SOUND = "Glass";
-
 interface BaseInput {
   type: "command" | "http" | "mcp_tool" | "prompt" | "agent";
   if: string;
@@ -79,7 +77,6 @@ async function main() {
   try {
     await Promise.all([
       execFileAsync("osascript", ["-e", script, "--", data.message, data.title]),
-      execFileAsync("afplay", [`/System/Library/Sounds/${SOUND}.aiff`]),
     ]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -44,7 +44,6 @@ async function main() {
   try {
     input = await Bun.stdin.text();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
     process.exit(1);
   }
 
@@ -52,7 +51,6 @@ async function main() {
   try {
     data = JSON.parse(input);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
     process.exit(1);
   }
 
@@ -72,7 +70,6 @@ async function main() {
     // argv[0]=message body, argv[1]=subtitle (title is hardcoded to "Claude Code")
     await execFileAsync("osascript", ["-e", script, "--", data.message, data.title]);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
     process.exit(1);
   }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -116,15 +116,6 @@
             "command": "bun ~/.claude/scripts/notification.ts"
           }
         ]
-      },
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "afplay '/System/Library/Sounds/Glass.aiff'"
-          }
-        ]
       }
     ],
     "Stop": [
@@ -169,6 +160,5 @@
         "any-script-mcp"
       ]
     }
-  },
-  "model": "sonnet"
+  }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -109,11 +109,31 @@
   "hooks": {
     "Notification": [
       {
-        "matcher": "*",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
             "command": "bun ~/.claude/scripts/notification.ts"
+          }
+        ]
+      },
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay '/System/Library/Sounds/Glass.aiff'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay '/System/Library/Sounds/Blow.aiff'"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -153,6 +153,7 @@
   "autoUpdatesChannel": "latest",
   "theme": "dark-ansi",
   "editorMode": "vim",
+  "prefersReducedMotion": true,
   "mcpServers": {
     "any-script": {
       "command": "npx",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [],
     "deny": [
@@ -112,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"Claude Codeが許可を求めています\" with title \"Claude Code\" subtitle \"確認待ち\" sound name \"Glass\"'"
+            "command": "bun ~/.claude/scripts/notification.ts"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -124,7 +124,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "afplay '/System/Library/Sounds/Blow.aiff'"
+            "command": "bun ~/.claude/scripts/notification.ts stop"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -136,14 +136,18 @@
       }
     }
   },
+  "language": "Japanese",
+  "effortLevel": "high",
+  "autoUpdatesChannel": "latest",
+  "theme": "dark-ansi",
+  "editorMode": "vim",
   "mcpServers": {
     "any-script": {
       "command": "npx",
-      "args": ["any-script-mcp"]
+      "args": [
+        "any-script-mcp"
+      ]
     }
   },
-  "language": "Japanese",
-  "autoUpdatesChannel": "latest",
-  "theme": "dark-ansi",
-  "effortLevel": "high"
+  "model": "sonnet"
 }

--- a/claude/test_notification.sh
+++ b/claude/test_notification.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export CLAUDE_HOOK_TEST=1
 readonly SCRIPT=(bun "${HOME}/.claude/scripts/notification.ts")
 PASS=0
 FAIL=0
@@ -45,7 +46,7 @@ run_test "stop (valid)" \
   0 \
   "stop"
 
-# stop: stop_hook_active true, exits 0
+# stop: stop_hook_active true, exits 0 without sending notification (hook still running)
 run_test "stop (stop_hook_active: true)" \
   '{"hook_event_name":"Stop","stop_hook_active":true,"last_assistant_message":"Interrupted.","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/tmp","permission_mode":"default","effort":"high"}' \
   0 \

--- a/claude/test_notification.sh
+++ b/claude/test_notification.sh
@@ -9,11 +9,14 @@ run_test() {
   local label="$1"
   local input="$2"
   local expect_exit="$3"
+  local mode="${4:-}"
   local actual_exit=0
   local output
+  local cmd=("${SCRIPT[@]}")
+  [[ -n "${mode}" ]] && cmd+=("${mode}")
 
   echo "=== ${label} ==="
-  output=$(printf '%s' "${input}" | "${SCRIPT[@]}" 2>&1) || actual_exit=$?
+  output=$(printf '%s' "${input}" | "${cmd[@]}" 2>&1) || actual_exit=$?
 
   if [[ "${actual_exit}" -eq "${expect_exit}" ]]; then
     echo "✓ exit ${actual_exit}"
@@ -35,6 +38,36 @@ run_test "permission_prompt" \
 run_test "idle_prompt (skipped)" \
   '{"hook_event_name":"Notification","notification_type":"idle_prompt","message":"Waiting for input","title":"Idle","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/Users/tsuyoshi/dotfiles","type":"command","if":"","timeout":60,"statusMessage":"","once":false}' \
   0
+
+# stop: valid input, exits 0 and shows macOS notification
+run_test "stop (valid)" \
+  '{"hook_event_name":"Stop","stop_hook_active":false,"last_assistant_message":"I have completed the task.","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/tmp","permission_mode":"default","effort":"high"}' \
+  0 \
+  "stop"
+
+# stop: stop_hook_active true, exits 0
+run_test "stop (stop_hook_active: true)" \
+  '{"hook_event_name":"Stop","stop_hook_active":true,"last_assistant_message":"Interrupted.","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/tmp","permission_mode":"default","effort":"high"}' \
+  0 \
+  "stop"
+
+# stop: missing last_assistant_message, exits 1
+run_test "stop (missing last_assistant_message)" \
+  '{"hook_event_name":"Stop","stop_hook_active":false,"session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/tmp","permission_mode":"default","effort":"high"}' \
+  1 \
+  "stop"
+
+# stop: missing stop_hook_active, exits 1
+run_test "stop (missing stop_hook_active)" \
+  '{"hook_event_name":"Stop","last_assistant_message":"Done.","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/tmp","permission_mode":"default","effort":"high"}' \
+  1 \
+  "stop"
+
+# stop: invalid JSON, exits 1
+run_test "stop (invalid JSON)" \
+  'not-json' \
+  1 \
+  "stop"
 
 # missing required field (message): exits 1
 run_test "missing message field" \

--- a/claude/test_notification.sh
+++ b/claude/test_notification.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="bun ~/.claude/scripts/notification.ts"
+PASS=0
+FAIL=0
+
+run_test() {
+  local label="$1"
+  local input="$2"
+  local expect_exit="$3"
+
+  echo "=== ${label} ==="
+  actual_exit=0
+  output=$(echo "${input}" | eval "${SCRIPT}" 2>&1) || actual_exit=$?
+
+  if [[ "${actual_exit}" -eq "${expect_exit}" ]]; then
+    echo "✓ exit ${actual_exit}"
+    PASS=$((PASS + 1))
+  else
+    echo "✗ expected exit ${expect_exit}, got ${actual_exit}"
+    FAIL=$((FAIL + 1))
+  fi
+  [[ -n "${output}" ]] && echo "${output}"
+  echo ""
+}
+
+# permission_prompt: shows macOS notification, exits 0
+run_test "permission_prompt" \
+  '{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"Claude needs your permission to use Bash","title":"Permission needed","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/Users/tsuyoshi/dotfiles","type":"command","if":"","timeout":60,"statusMessage":"","once":false}' \
+  0
+
+# idle_prompt: skips notification silently, exits 0
+run_test "idle_prompt (skipped)" \
+  '{"hook_event_name":"Notification","notification_type":"idle_prompt","message":"Waiting for input","title":"Idle","session_id":"abc123","transcript_path":"/tmp/test.jsonl","cwd":"/Users/tsuyoshi/dotfiles","type":"command","if":"","timeout":60,"statusMessage":"","once":false}' \
+  0
+
+# missing required field (message): exits 1
+run_test "missing message field" \
+  '{"hook_event_name":"Notification","notification_type":"permission_prompt","title":"Permission needed"}' \
+  1
+
+# missing required field (title): exits 1
+run_test "missing title field" \
+  '{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"Some message"}' \
+  1
+
+# invalid JSON: exits 1
+run_test "invalid JSON" \
+  'not-json' \
+  1
+
+# empty input: exits 1
+run_test "empty input" \
+  '' \
+  1
+
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[[ "${FAIL}" -eq 0 ]]

--- a/claude/test_notification.sh
+++ b/claude/test_notification.sh
@@ -44,7 +44,7 @@ run_test "missing message field" \
 # missing required field (title): exits 1
 run_test "missing title field" \
   '{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"Some message"}' \
-  1
+  0
 
 # invalid JSON: exits 1
 run_test "invalid JSON" \

--- a/claude/test_notification.sh
+++ b/claude/test_notification.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT="bun ~/.claude/scripts/notification.ts"
+readonly SCRIPT=(bun "${HOME}/.claude/scripts/notification.ts")
 PASS=0
 FAIL=0
 
@@ -9,10 +9,11 @@ run_test() {
   local label="$1"
   local input="$2"
   local expect_exit="$3"
+  local actual_exit=0
+  local output
 
   echo "=== ${label} ==="
-  actual_exit=0
-  output=$(echo "${input}" | eval "${SCRIPT}" 2>&1) || actual_exit=$?
+  output=$(printf '%s' "${input}" | "${SCRIPT[@]}" 2>&1) || actual_exit=$?
 
   if [[ "${actual_exit}" -eq "${expect_exit}" ]]; then
     echo "✓ exit ${actual_exit}"

--- a/claude/test_notification.sh
+++ b/claude/test_notification.sh
@@ -74,7 +74,7 @@ run_test "missing message field" \
   '{"hook_event_name":"Notification","notification_type":"permission_prompt","title":"Permission needed"}' \
   1
 
-# missing required field (title): exits 1
+# title is optional: falls back to capitalized notification_type, exits 0
 run_test "missing title field" \
   '{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"Some message"}' \
   0

--- a/claude/test_statusline.sh
+++ b/claude/test_statusline.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 echo "=== 30% === "
 bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":30000}},"rate_limits":{"five_hour":{"used_percentage":30,"resets_at":1746700000},"seven_day":{"used_percentage":30,"resets_at":1746700000}}}'
 echo ""

--- a/claude/test_statusline.sh
+++ b/claude/test_statusline.sh
@@ -1,0 +1,23 @@
+echo "=== 30% === "
+bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":30000}},"rate_limits":{"five_hour":{"used_percentage":30,"resets_at":1746700000},"seven_day":{"used_percentage":30,"resets_at":1746700000}}}'
+echo ""
+
+echo "=== 60% ==="
+bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":60000}},"rate_limits":{"five_hour":{"used_percentage":60,"resets_at":1746700000},"seven_day":{"used_percentage":60,"resets_at":1746700000}}}'
+echo ""
+
+echo "=== 80% ==="
+bun run claude/statusline.ts <<< '{"model":{"id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":80000}},"rate_limits":{"five_hour":{"used_percentage":80,"resets_at":1746700000},"seven_day":{"used_percentage":80,"resets_at":1746700000}}}'
+echo ""
+
+echo "=== display_name includes arn ==="
+bun run claude/statusline.ts <<< '{"model":{"id":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0","display_name":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"}}'
+echo ""
+
+echo "=== model id includes but display_name is friendly ==="
+bun run claude/statusline.ts <<< '{"model":{"id":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0","display_name":"Claude 3.5 Sonnet"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"}}'
+echo ""
+
+echo "=== by AWS and context usage included ==="
+bun run claude/statusline.ts <<< '{"model":{"id":"arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0","display_name":"Claude 3.5 Sonnet"},"workspace":{"current_dir":"/Users/tsuyoshi/dotfiles"},"context_window":{"context_window_size":100000,"current_usage":{"input_tokens":80000}},"rate_limits":{"five_hour":{"used_percentage":80,"resets_at":1746700000}}}'
+echo ""

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -94,3 +94,9 @@ set -g @plugin 'hiroppy/tmux-agent-sidebar'
 
 run -b '~/.tmux/plugins/tpm/tpm'
 
+
+### For Claude Code
+###############################################################################
+set -g allow-passthrough on
+set -s extended-keys on
+set -as terminal-features 'xterm*:extkeys'

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -100,3 +100,7 @@ run -b '~/.tmux/plugins/tpm/tpm'
 set -g allow-passthrough on
 set -s extended-keys on
 set -as terminal-features 'xterm*:extkeys'
+
+# Filter desktop notification from tmux-agent-sidebar
+# https://hiroppy.github.io/tmux-agent-sidebar/features/notifications/
+set -g @sidebar_notifications_events "stop_failure,permission_denied,task_completed"


### PR DESCRIPTION
## Summary

### Terminal configuration
- Add Shift+Enter keybinding to alacritty for Claude Code multi-line prompt input
- Enable `allow-passthrough` and `extended-keys` in tmux for Claude Code terminal protocol compatibility

### Claude settings
- Update `claude/settings.json` with language (Japanese), theme (dark-ansi), editorMode (vim), effortLevel (high), and model (sonnet)

### Notification hook
- Add `claude/scripts/notification.ts` — notification hook script that shows macOS notifications and plays sound via `afplay`
- Simplify settings.json: replace hardcoded osascript hook with the dedicated script; `afplay` bypasses macOS notification sound settings that would suppress sound
- Add `claude/test_notification.sh` to test notification rendering across various scenarios

### Statusline
- Add `claude/test_statusline.sh` to test statusline rendering across various usage/model scenarios

## Test plan

- [ ] Shift+Enter in alacritty creates a new line instead of submitting
- [ ] Claude Code works correctly inside tmux (passthrough events, extended keys)
- [ ] Claude Code UI reflects updated settings (Japanese, dark-ansi theme, vim mode)
- [ ] `bash claude/test_notification.sh` — all 6 cases pass, sound plays on permission_prompt
- [ ] `bash claude/test_statusline.sh` — outputs correct statusline for all test cases