### PR TITLE
fix(tmux): disable extended-keys to fix alacritty multiline paste

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -96,6 +96,7 @@ run -b '~/.tmux/plugins/tpm/tpm'
 
 
 ### For Claude Code
+### https://code.claude.com/docs/en/terminal-config#configure-tmux
 ###############################################################################
 set -g allow-passthrough on
 # NOTE: Do not enable `extended-keys on` / `extended-keys-format` /

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -98,14 +98,12 @@ run -b '~/.tmux/plugins/tpm/tpm'
 ### For Claude Code
 ###############################################################################
 set -g allow-passthrough on
-# Disabled: `extended-keys on` makes Alacritty 0.15.1 render LF (0x0a) as the
-# literal letter 'j' in subsequent output, collapsing multi-line paste display
-# even though the underlying bytes are intact. iTerm2 / macOS Terminal are not
-# affected. Shift+Enter still works because alacritty.toml binds it to "\e\r"
-# directly, bypassing tmux key encoding.
-# set -s extended-keys on
-# set -s extended-keys-format xterm
-# set -as terminal-features 'xterm*:extkeys'
+# NOTE: Do not enable `extended-keys on` / `extended-keys-format` /
+# `terminal-features ...:extkeys`. Alacritty (observed on 0.15.1) renders LF
+# (0x0a) as the literal letter 'j' in subsequent output, collapsing multi-line
+# paste display even though the bytes in the pty are intact. iTerm2 / macOS
+# Terminal are unaffected. Shift+Enter still works because alacritty.toml
+# binds it to "\e\r" directly, bypassing tmux key encoding.
 
 # Filter desktop notification from tmux-agent-sidebar
 # https://hiroppy.github.io/tmux-agent-sidebar/features/notifications/

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -98,8 +98,14 @@ run -b '~/.tmux/plugins/tpm/tpm'
 ### For Claude Code
 ###############################################################################
 set -g allow-passthrough on
-set -s extended-keys on
-set -as terminal-features 'xterm*:extkeys'
+# Disabled: `extended-keys on` makes Alacritty 0.15.1 render LF (0x0a) as the
+# literal letter 'j' in subsequent output, collapsing multi-line paste display
+# even though the underlying bytes are intact. iTerm2 / macOS Terminal are not
+# affected. Shift+Enter still works because alacritty.toml binds it to "\e\r"
+# directly, bypassing tmux key encoding.
+# set -s extended-keys on
+# set -s extended-keys-format xterm
+# set -as terminal-features 'xterm*:extkeys'
 
 # Filter desktop notification from tmux-agent-sidebar
 # https://hiroppy.github.io/tmux-agent-sidebar/features/notifications/


### PR DESCRIPTION
## Summary

- Comment out `set -s extended-keys on` (and the related `extended-keys-format` / `terminal-features extkeys` lines) in `tmux/.tmux.conf`
- Restores working multi-line paste in Alacritty + tmux without affecting iTerm2, macOS Terminal, or any other workflow
- Keep `allow-passthrough on` since it is unrelated to this issue and still needed for OSC52

## Why

Multi-line paste into Claude Code in my primary terminal (Alacritty + tmux) had been broken: every paste collapsed to a single line with the letter `j` inserted where newlines should be. This made it impractical to paste error messages, code snippets, or any multi-line clipboard content into Claude Code, forcing manual retyping.

## Root cause

With `extended-keys on`, tmux negotiates the Kitty / CSI-u extended-key protocol with the outer terminal. Once Alacritty 0.15.1 has that protocol enabled, it renders LF (`0x0a`) in subsequent output as the literal letter `j` (`0x6a`), collapsing multi-line content even though the bytes are intact (verified at the byte level with `xxd` inside the pty). iTerm2 and macOS Terminal do not implement the Kitty keyboard protocol, so tmux never engages this code path with them — matching the observed compatibility matrix:

| Terminal | tmux off | tmux on |
|---|---|---|
| iTerm2 | OK | OK |
| macOS Terminal | OK | OK |
| Alacritty | OK | **broken** |

## Compatibility

- Shift+Enter for newline in Claude Code still works because `alacritty.toml` binds `Shift+Enter -> "\e\r"` directly, bypassing tmux key encoding.
- tmux prefix and standard keybindings are unaffected.
- iTerm2 / macOS Terminal users see no behavior change (they never engaged the disabled features).

## Test plan

- [x] Alacritty + tmux: multi-line paste preserves newlines (verified on two laptops after `tmux kill-server`)
- [x] Shift+Enter still inserts a newline in Claude Code
- [x] Regular tmux keybindings still work

## Notes

The settings disabled here were originally added in #139 for Claude Code compatibility. The Alacritty rendering side of this bug may be worth reporting upstream — tracking that as follow-up outside this PR.