### PR TITLE
chore(brew): add tree-sitter-cli to shared packages

### DIFF
--- a/Brewfile.shared
+++ b/Brewfile.shared
@@ -84,6 +84,7 @@ brew "tailspin"
 brew "the_silver_searcher"
 brew "tmux"
 brew "tree"
+brew "tree-sitter-cli"
 brew "watch"
 brew "yarn"
 brew "datawire/blackbird/telepresence", link: false


### PR DESCRIPTION
## Summary

- Add `tree-sitter-cli` to the shared Homebrew package list

## Why

`tree-sitter-cli` is needed as a development tool for working with Tree-sitter grammars and parsers. Adding it to the shared Brewfile ensures it is consistently available across all machines managed by this dotfiles setup.

## Changes

- `Brewfile.shared`: add `brew "tree-sitter-cli"`

## Test Plan

- [ ] Run `brew bundle --file=Brewfile.shared` to verify the package installs correctly