### PR TITLE
fix(ci): restore checkout in detect-changes for push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       brewfile: ${{ steps.filter.outputs.brewfile }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Summary

Restore `actions/checkout@v4` in the `detect-changes` job that was incorrectly removed in #144.

## Why

`dorny/paths-filter` uses the GitHub API to compute diffs for `pull_request` events and does not need a checkout. However, for `push` events it requires git history, causing exit code 128 on `main` after the merge.

## Changes

- `.github/workflows/ci.yml`: add back `actions/checkout@v4` to `detect-changes`