### PR TITLE
feat(zsh): add XDG Base Directory variables to .zshenv

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,3 +1,9 @@
+# XDG Base Directory
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
 if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/runcoms/zshenv" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/runcoms/zshenv"
 fi


### PR DESCRIPTION
## Summary

- Add `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, and `XDG_STATE_HOME` to `zsh/.zshenv`
- Use `${VAR:-default}` form so existing values are respected
- `ZDOTDIR` is intentionally **not** set in this PR — zsh continues reading from `$HOME`

## Why

Part of the XDG Base Directory migration (#138). Establishing these variables first is a safe, non-breaking prerequisite that makes them available to subsequent phases without changing any shell startup behavior.

## Changes

- `zsh/.zshenv`: prepend XDG variable exports before the existing Prezto runcom source

## Test Plan

- [x] `zsh -i -c 'echo $XDG_CONFIG_HOME'` → `/Users/tsuyoshi/.config`
- [x] `zsh -i -c 'echo ${ZDOTDIR:-unset}'` → `unset` (no regression)
- [x] Shell starts normally with existing aliases, completions, and prompt

## Notes

This is Phase 1 of a 3-phase migration. Phase 2 (zsh config move + `ZDOTDIR`) and Phase 3 (tmux + tpm) will follow in separate PRs.

Partial progress on #138