### PR TITLE
fix(claude): cover XDG credentials path in deny rule

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -12,6 +12,7 @@
       "Read(.envrc)",
       "Read(id_rsa)",
       "Read(**/.credentials.zsh)",
+      "Read(**/credentials.zsh)",
       "Read(**/*token*)",
       "Read(**/*key*)",
       "Read(**/*secret*)",


### PR DESCRIPTION
## Summary

- Add `Read(**/credentials.zsh)` to the deny list so the post-XDG credentials file is still read-protected

## Why

After the XDG migration in #149, the credentials file moved from `~/.credentials.zsh` to `~/.config/zsh/credentials.zsh` (no leading dot). The existing `Read(**/.credentials.zsh)` glob does not match the dot-less name, leaving the GitHub token and other secrets in that file readable by Claude.

## Changes

- **`claude/settings.json`**: add `Read(**/credentials.zsh)` next to the existing rule; keep the legacy `Read(**/.credentials.zsh)` so a machine that is partway through the migration is still covered

## Test Plan

- [x] `jq . claude/settings.json` parses cleanly
- [ ] On the live machine, confirm Claude is blocked from reading `~/.config/zsh/credentials.zsh`

Closes #150