### PR TITLE
refactor(tmux): move tmux.conf under XDG_CONFIG_HOME (#138 Phase 3)

### DIFF
--- a/docs/MULTI_MACHINE_WORKFLOW.md
+++ b/docs/MULTI_MACHINE_WORKFLOW.md
@@ -59,7 +59,7 @@ git pull origin main
 git checkout -b feature/add-tmux-plugin
 
 # Make changes
-# Edit tmux/.tmux.conf or any shared config
+# Edit tmux/.config/tmux/tmux.conf or any shared config
 
 # Commit
 git add .
@@ -187,7 +187,7 @@ brew bundle --file=Brewfile.work
 ### What Goes in Each Branch?
 
 **main branch** (shared):
-- Core shell configs: `.zshrc`, `.zshenv`, `.tmux.conf`
+- Core shell configs: `.zshrc`, `.zshenv`, `tmux.conf`
 - Editor configs: `nvim/`, `vscode/`
 - Tool configs: `alacritty/`, `starship/`, `bat/`
 - Shared Brewfile: `Brewfile.shared`

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -88,6 +88,8 @@ bind h select-pane -L
 # NOTE: Clone tpm first!
 #  git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 ###############################################################################
+set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.tmux/plugins/'
+
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'hiroppy/tmux-agent-sidebar'

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -60,7 +60,7 @@ set -g display-panes-colour ${gray_medium}
 ###############################################################################
 unbind ^C
 
-bind r source-file ~/.tmux.conf; display-message "Configuration has been Reloaded."
+bind r source-file ~/.config/tmux/tmux.conf; display-message "Configuration has been Reloaded."
 
 bind c new-window
 bind p previous-window

--- a/up
+++ b/up
@@ -64,6 +64,14 @@ function migrate_to_xdg()
             return 1
         }
     fi
+
+    # Sweep a stale ~/.tmux.conf symlink left over from the pre-XDG tmux layout.
+    # Only act on a dangling symlink (broken target) so we never touch a real
+    # file the user might still want.
+    if [ -L "$HOME/.tmux.conf" ] && [ ! -e "$HOME/.tmux.conf" ]; then
+        echo "Removing dangling symlink ~/.tmux.conf (stale from pre-XDG layout)"
+        rm -f "$HOME/.tmux.conf"
+    fi
 }
 
 function run_stow()
@@ -141,19 +149,29 @@ function install_global_npm_packages()
 
 function install_tmux_plugins()
 {
+  local tpm_dir="$HOME/.tmux/plugins/tpm"
   if type tmux > /dev/null 2>&1 ; then
-    if [ -d ~/.tmux/plugins/tpm ]; then
+    if [ -d "$tpm_dir" ]; then
       echo 'tpm is already installed!'
     else
-      echo 'install tpm'
+      echo "install tpm to $tpm_dir"
       # https://github.com/tmux-plugins/tpm
-      git clone https://github.com/tmux-plugins/tpm.git ~/.tmux/plugins/tpm
+      mkdir -p "$(dirname "$tpm_dir")" || {
+        echo "ERROR: Failed to create $(dirname "$tpm_dir")" >&2
+        return 1
+      }
+      git clone https://github.com/tmux-plugins/tpm.git "$tpm_dir" || {
+        echo "ERROR: Failed to clone tpm into $tpm_dir" >&2
+        echo "       Check network connectivity and that the directory does not already exist." >&2
+        return 1
+      }
 
       echo 'Create tmux session and run the following command in the session.'
       echo 'prefix + I (ctrl + t → I)'
     fi
   else
-    echo 'Install tmux first!'
+    echo 'ERROR: tmux is not installed. Run: ./up brew' >&2
+    return 1
   fi
 }
 
@@ -174,6 +192,7 @@ function main()
             install_global_npm_packages
             ;;
         "tmux")
+            migrate_to_xdg
             install_tmux_plugins
             ;;
         *)


### PR DESCRIPTION
## Summary

- Move `tmux.conf` under `~/.config/tmux/` (which tmux >= 3.1 reads automatically)
- Update the reload binding (`prefix + r`) to point at the new path
- Keep the tpm plugin directory at the tpm default `~/.tmux/plugins/` — see Notes for the rationale
- Harden `up` around tmux setup and clean up the stale `~/.tmux.conf` symlink the rename leaves behind

## Why

Final phase of the XDG Base Directory migration (#138). Moving the visible `~/.tmux.conf` removes the last shell-related dotfile from `$HOME`. The tpm plugin directory was considered too, but `~/.tmux/` is a hidden runtime directory and exporting `TMUX_PLUGIN_MANAGER_PATH` plus migrating an entire plugin tree adds more friction than the benefit of removing one hidden dir is worth — so it stays at the tpm default and this PR is scoped down to the config file.

## Changes

- **`tmux/.config/tmux/tmux.conf`** (moved from `tmux/.tmux.conf`): reload binding (`prefix + r`) now sources `~/.config/tmux/tmux.conf`
- **`up`**:
  - `migrate_to_xdg` sweeps a dangling `~/.tmux.conf` symlink left over from the rename (guarded so a real file the user kept is preserved); `./up tmux` now calls `migrate_to_xdg` first so the sweep also fires when that subcommand is used
  - `install_tmux_plugins` surfaces `mkdir` / `git clone` failures with context and returns non-zero when tmux itself is not installed
- **`docs/MULTI_MACHINE_WORKFLOW.md`**: refresh tmux paths

## Test Plan

- [x] `zsh -n up` parses cleanly; `jq . claude/settings.json` valid
- [x] Net diff vs `main`: 3 files (tmux.conf rename, docs, up). `.zshenv` and `claude/settings.json` are untouched
- [ ] Live cutover (post-merge): `./up stow` re-links the new `~/.config/tmux/tmux.conf` and removes the stale `~/.tmux.conf` symlink

## Notes

**Post-merge cutover** (on each machine):

```sh
git -C ~/dotfiles checkout main && git -C ~/dotfiles pull
~/dotfiles/up stow   # links the new ~/.config/tmux/tmux.conf and clears stale ~/.tmux.conf
tmux source-file ~/.config/tmux/tmux.conf   # for currently running sessions, or restart tmux
```

**Why tpm/plugins stay at `~/.tmux/plugins/`**: this PR originally also relocated tpm under `$XDG_DATA_HOME/tmux/plugins/`. That required exporting `TMUX_PLUGIN_MANAGER_PATH` from `.zshenv`, a cross-filesystem-safe migration step in `migrate_to_xdg`, and diverging from tpm's published install path. After weighing it, the cost did not justify removing a hidden directory from `$HOME`, so the plugin migration is dropped from this PR; the dotfile cleanup (`~/.tmux.conf` going away) is preserved.

Relates to #138. Closes the issue once merged.
