### PR TITLE
feat(claude): add UserPromptSubmit hook to review English prompts

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -125,6 +125,17 @@
     ]
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Present this short review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.\"}}'"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -131,7 +131,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Present this short review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Always write this review in Japanese, even though the prompt itself is in English. Present this short Japanese review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.\"}}'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Add a `UserPromptSubmit` hook to the global Claude Code settings
- On every prompt, when the prompt is written in English, the assistant first reviews it — grammar mistakes, unnatural phrasing, and a more natural rewrite — before answering
- **The review itself is always written in Japanese** (even though the reviewed prompt is in English), so feedback stays in my working language
- Non-English prompts are answered as usual with no review

## Why

I want lightweight, always-on feedback on my English writing while using Claude Code, without having to ask for it each time. A `UserPromptSubmit` hook guarantees the behavior fires on every prompt — unlike a CLAUDE.md instruction, which the model may deprioritize as context grows. Implementing it as a dependency-free `echo` command keeps it fast and model-agnostic, so it works the same on Opus, Sonnet, or Haiku.

I also want the review output in Japanese. Without an explicit instruction the model tended to mirror the prompt's language and reply in English, so the hook now states the review must always be in Japanese.

## Changes

- `claude/settings.json`: add a `UserPromptSubmit` hook that injects `additionalContext` with the review instruction. Existing `Notification` and `Stop` hooks are preserved.
- The injected instruction directs the assistant to **render the review in Japanese**, while still answering the actual request normally.

## Test Plan

- [x] `jq` validates the hook command nesting under `.hooks.UserPromptSubmit`
- [x] Running the hook command emits valid JSON with the expected `additionalContext`
- [x] Confirmed in-session that the reminder is injected on prompt submit
- [x] Submit an English prompt and confirm the review appears **in Japanese** before the answer
- [ ] Submit a Japanese prompt and confirm no review is shown

## Notes

- The hook always injects the reminder; the English/non-English decision is delegated to the model rather than done in shell, keeping the command simple and avoiding language-detection false positives.
- `~/.claude/settings.json` is a symlink into this repo's working tree, so the hook only takes effect where the working tree contains it. Merging to `main` is what makes it consistent across all sessions and machines.
