### PR TITLE
feat(scripts): add create-ai-log CLI tool

### DIFF
--- a/bin/.local/bin/create-ai-log
+++ b/bin/.local/bin/create-ai-log
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v bun > /dev/null 2>&1; then
+    echo "create-ai-log: 'bun' is not installed or not on PATH." >&2
+    echo "Install it with: curl -fsSL https://bun.sh/install | bash" >&2
+    exit 127
+fi
+
+SCRIPT="${HOME}/dotfiles/scripts/create_ai_log.ts"
+if [[ ! -f "${SCRIPT}" ]]; then
+    echo "create-ai-log: target script not found: ${SCRIPT}" >&2
+    echo "Ensure dotfiles is cloned at ~/dotfiles and run: ./up dot" >&2
+    exit 1
+fi
+
+exec bun "${SCRIPT}" "$@"

--- a/scripts/create_ai_log.ts
+++ b/scripts/create_ai_log.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env bun
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const cwd = process.cwd();
+
+const today = new Date();
+const year = today.getFullYear();
+const month = `${(today.getMonth() + 1).toString().padStart(2, "0")}`;
+const day = `${today.getDate().toString().padStart(2, "0")}`;
+const date = `${year}${month}${day}`;
+
+const title = process.argv[2];
+if (!title) {
+  console.error("Error: Title is required.");
+  process.exit(1);
+}
+
+const logDirPath = join(cwd, "./.ai_logs", `${year}`, `${month}`);
+
+if (!existsSync(logDirPath)) {
+  mkdirSync(logDirPath, { recursive: true });
+}
+
+console.log(
+  `Creating log file: ${join(logDirPath, `${date}_${title.replace(/ /g, "_")}.md`)}`,
+);
+
+writeFileSync(join(logDirPath, `${date}_${title.replace(/ /g, "_")}.md`), "");
+
+console.log("Log file created successfully.");
+process.exit(0);


### PR DESCRIPTION
## Summary

- `.ai_logs` ディレクトリ配下に日付ベースのMarkdownファイルを自動生成するCLIツールを追加
- `scripts/create_ai_log.ts`: bun で実行するTypeScriptスクリプト本体
- `bin/.local/bin/create-ai-log`: `~/dotfiles/scripts/create_ai_log.ts` へ委譲するbashラッパー

## Why

CLAUDE.md の規約として `.ai_logs/YYYY/MM/YYYYMMDD_<title>.md` 形式でログファイルを管理しているが、ディレクトリ構造の作成とファイル名フォーマットを毎回手動で行うのは手間がかかる。このツールにより `create-ai-log <title>` の一発コマンドで正しい場所にファイルを生成できる。

## Changes

- `scripts/create_ai_log.ts`: 引数からタイトルを受け取り、日付フォーマットのパスにMarkdownファイルを作成するbunスクリプト
- `bin/.local/bin/create-ai-log`: bunの有無とスクリプトの存在を検証してから実行するbashラッパー

## Test Plan

- [x] `create-ai-log "my topic"` を実行して `.ai_logs/YYYY/MM/YYYYMMDD_my_topic.md` が生成されることを確認
- [ ] `bun` が未インストールの場合にエラーメッセージが表示されることを確認
- [x] タイトル引数を省略した場合に `Error: Title is required.` が表示されることを確認