### PR TITLE
fix(claude): fix english-review hook to read prompt from stdin

### DIFF
--- a/claude/scripts/english-review-hook.ts
+++ b/claude/scripts/english-review-hook.ts
@@ -3,39 +3,37 @@
 const ENGLISH_REVIEW_CONTEXT =
   "If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Always write this review in Japanese, even though the prompt itself is in English. Present this short Japanese review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.";
 
+// Skip review for short prompts (quick commands) to avoid noise
 const MIN_PROMPT_LENGTH = 30;
 
+// Only the fields this script actually reads from the hook payload
+// See the full input schema https://code.claude.com/docs/ja/hooks#userpromptsubmit-input
 interface UserPromptSubmitData {
-  session_id: string;
-  transcript_path: string;
-  cwd: string;
-  permission_mode: string;
   hook_event_name: "UserPromptSubmit";
   prompt: string;
 }
 
+// Returns true only when the two fields this script uses are present and typed correctly
 function isValidUserPromptSubmitData(input: unknown): input is UserPromptSubmitData {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     return false;
   }
   const obj = input as Record<string, unknown>;
-  return (
-    obj.hook_event_name === "UserPromptSubmit" && typeof obj.prompt === "string"
-  );
+  return obj.hook_event_name === "UserPromptSubmit" && typeof obj.prompt === "string";
 }
 
 async function main() {
   let input: string;
   try {
     input = await Bun.stdin.text();
-  } catch (error) {
+  } catch {
     process.exit(0);
   }
 
   let data: unknown;
   try {
     data = JSON.parse(input);
-  } catch (error) {
+  } catch {
     process.exit(0);
   }
 
@@ -56,4 +54,4 @@ async function main() {
   process.stdout.write(JSON.stringify(output));
 }
 
-main();
+main().catch(() => process.exit(0));

--- a/claude/scripts/english-review-hook.ts
+++ b/claude/scripts/english-review-hook.ts
@@ -5,9 +5,45 @@ const ENGLISH_REVIEW_CONTEXT =
 
 const MIN_PROMPT_LENGTH = 30;
 
-function main() {
-  const prompt = process.env.CLAUDE_USER_PROMPT ?? "";
-  if (prompt.length < MIN_PROMPT_LENGTH) {
+interface UserPromptSubmitData {
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+  permission_mode: string;
+  hook_event_name: "UserPromptSubmit";
+  prompt: string;
+}
+
+function isValidUserPromptSubmitData(input: unknown): input is UserPromptSubmitData {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return false;
+  }
+  const obj = input as Record<string, unknown>;
+  return (
+    obj.hook_event_name === "UserPromptSubmit" && typeof obj.prompt === "string"
+  );
+}
+
+async function main() {
+  let input: string;
+  try {
+    input = await Bun.stdin.text();
+  } catch (error) {
+    process.exit(0);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(input);
+  } catch (error) {
+    process.exit(0);
+  }
+
+  if (!isValidUserPromptSubmitData(data)) {
+    process.exit(0);
+  }
+
+  if (data.prompt.length < MIN_PROMPT_LENGTH) {
     process.exit(0);
   }
 

--- a/claude/scripts/english-review-hook.ts
+++ b/claude/scripts/english-review-hook.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+
+const ENGLISH_REVIEW_CONTEXT =
+  "If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Always write this review in Japanese, even though the prompt itself is in English. Present this short Japanese review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.";
+
+const MIN_PROMPT_LENGTH = 30;
+
+function main() {
+  const prompt = process.env.CLAUDE_USER_PROMPT ?? "";
+  if (prompt.length < MIN_PROMPT_LENGTH) {
+    process.exit(0);
+  }
+
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: ENGLISH_REVIEW_CONTEXT,
+    },
+  };
+  process.stdout.write(JSON.stringify(output));
+}
+
+main();

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'if [ ${#CLAUDE_USER_PROMPT} -ge 30 ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"UserPromptSubmit\\\",\\\"additionalContext\\\":\\\"If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Always write this review in Japanese, even though the prompt itself is in English. Present this short Japanese review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.\\\"}}\"; fi'"
+            "command": "bun ~/.claude/scripts/english-review-hook.ts"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -5,7 +5,9 @@
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr checks:*)",
-      "Bash(gh pr diff:*)"
+      "Bash(gh pr diff:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)"
     ],
     "deny": [
       "Read(.env*)",
@@ -124,6 +126,7 @@
       "Bash(bun install:*)"
     ]
   },
+  "model": "opus",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -131,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Always write this review in Japanese, even though the prompt itself is in English. Present this short Japanese review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.\"}}'"
+            "command": "bash -c 'if [ ${#CLAUDE_USER_PROMPT} -ge 30 ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"UserPromptSubmit\\\",\\\"additionalContext\\\":\\\"If the latest user prompt is written in English, then before addressing the request, first review the English: list (1) grammar mistakes, (2) unnatural phrasing, and (3) a more natural rewrite. Always write this review in Japanese, even though the prompt itself is in English. Present this short Japanese review first, then answer the request normally. If the prompt is not written in English, skip the review entirely and just answer.\\\"}}\"; fi'"
           }
         ]
       }
@@ -180,9 +183,9 @@
   "language": "Japanese",
   "effortLevel": "high",
   "autoUpdatesChannel": "latest",
+  "prefersReducedMotion": true,
   "theme": "dark-ansi",
   "editorMode": "vim",
-  "prefersReducedMotion": true,
   "mcpServers": {
     "any-script": {
       "command": "npx",


### PR DESCRIPTION
## Summary

- Extract `UserPromptSubmit` hook logic into a dedicated TypeScript script (`claude/scripts/english-review-hook.ts`)
- Fix the broken prompt-reading approach: the hook previously relied on a `CLAUDE_USER_PROMPT` env variable (which does not exist); it now correctly reads hook data as JSON from stdin
- Skip the English review for prompts shorter than 30 characters to avoid noise on short commands
- Treat all parse/validation failures as silent skips (`exit(0)`) so hook errors never surface to the user

## Why

The inline `echo` command in `settings.json` had no way to inspect the prompt, so adding a minimum-length check required moving the logic into a script. The first attempt incorrectly relied on `process.env.CLAUDE_USER_PROMPT`, which the Claude Code harness never sets. Hook input is delivered via stdin as a JSON payload, so the script now reads and parses that correctly. Short prompts (typically quick commands) don't benefit from an English review and only add noise, hence the length threshold.

## Changes

- `claude/scripts/english-review-hook.ts` (new file):
  - Reads JSON from stdin (`Bun.stdin.text()`)
  - Validates the payload with an `isValidUserPromptSubmitData` type guard
  - Skips the review for prompts under 30 characters
  - Emits `additionalContext` JSON to stdout for valid prompts
  - Exits with `0` on any read/parse/validation failure (silent skip)
- `claude/settings.json`:
  - Replace the inline `echo` hook command with `bun ~/.claude/scripts/english-review-hook.ts`
  - Add `Bash(gh issue list:*)` and `Bash(gh issue view:*)` to the allow list
  - Add `"model": "opus"`
  - Minor key reordering (`prefersReducedMotion`)

## Test Plan

- [ ] Run the hook command manually with a sample JSON payload and confirm `additionalContext` is emitted
- [ ] Submit a short prompt (<30 chars) and confirm no review is shown
- [ ] Submit an English prompt (≥30 chars) and confirm the Japanese review appears before the answer
- [ ] Submit a Japanese prompt and confirm no review is shown
