### PR TITLE
feat(zsh): add zsh-history-substring-search and zsh-completions

### DIFF
--- a/zsh/.config/sheldon/plugins.toml
+++ b/zsh/.config/sheldon/plugins.toml
@@ -1,7 +1,17 @@
 shell = "zsh"
 
+[templates]
+fpath-src = 'fpath=( "{{ dir }}/src" $fpath )'
+
 [plugins.zsh-autosuggestions]
 github = "zsh-users/zsh-autosuggestions"
 
 [plugins.zsh-syntax-highlighting]
 github = "zsh-users/zsh-syntax-highlighting"
+
+[plugins.zsh-history-substring-search]
+github = "zsh-users/zsh-history-substring-search"
+
+[plugins.zsh-completions]
+github = "zsh-users/zsh-completions"
+apply = ["fpath-src"]

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -107,6 +107,8 @@ mkdir -p "${XDG_STATE_HOME:-$HOME/.local/state}/zsh" \
 export HISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/zsh/history"
 setopt inc_append_history
 setopt share_history
+setopt HIST_IGNORE_ALL_DUPS
+setopt HIST_REDUCE_BLANKS
 
 export HISTSIZE=100000
 export SAVEHIST=100000
@@ -126,6 +128,18 @@ eval "$(direnv hook zsh)"
 
 export GOENV_ROOT="$HOME/.goenv"
 eval "$(goenv init -)"
+
+####################################################################################################
+# Sheldon
+# Must be loaded before compinit so fpath additions (e.g. zsh-completions) are visible to it
+####################################################################################################
+if command -v sheldon > /dev/null 2>&1; then
+  eval "$(sheldon source)"
+else
+  echo '[zshrc] WARNING: sheldon not found. Run: ./up sheldon' >&2
+fi
+bindkey '^[[A' history-substring-search-up
+bindkey '^[[B' history-substring-search-down
 
 ####################################################################################################
 # Completion
@@ -158,16 +172,6 @@ bindkey -M menuselect 'h' vi-backward-char
 bindkey -M menuselect 'j' vi-down-line-or-history
 bindkey -M menuselect 'k' vi-up-line-or-history
 bindkey -M menuselect 'l' vi-forward-char
-
-####################################################################################################
-# Sheldon
-# Must be loaded after compinit (required by zsh-syntax-highlighting)
-####################################################################################################
-if command -v sheldon > /dev/null 2>&1; then
-  eval "$(sheldon source)"
-else
-  echo '[zshrc] WARNING: sheldon not found. Run: ./up sheldon' >&2
-fi
 
 ####################################################################################################
 # Utility functions


### PR DESCRIPTION
## Summary

- Add `zsh-history-substring-search` plugin for searching history by typed substring with arrow keys
- Add `zsh-completions` plugin to extend built-in completion definitions
- Move sheldon source before `compinit` so `zsh-completions` fpath is visible at initialization
- Add `HIST_IGNORE_ALL_DUPS` and `HIST_REDUCE_BLANKS` to history settings

## Why

Arrow key history search and richer completion definitions are two of the most impactful quality-of-life improvements for daily shell use. Loading sheldon before `compinit` is required so that `zsh-completions` additions to `fpath` are picked up when completion is initialized.

## Changes

- `zsh/.config/sheldon/plugins.toml`: Add `zsh-history-substring-search` and `zsh-completions`; define custom `fpath-src` template to add `zsh-completions/src` to fpath
- `zsh/.config/zsh/.zshrc`: Move sheldon block before the Completion section; add `bindkey` for history-substring-search up/down; add `HIST_IGNORE_ALL_DUPS` and `HIST_REDUCE_BLANKS`

## Test Plan

- [x] Source `.zshrc` and confirm no errors
- [x] Press up/down after typing a partial command — history-substring-search should filter matches
- [x] Trigger a completion (e.g. `git <Tab>`) — extended completions from `zsh-completions` should be available
- [x] Confirm duplicate history entries are no longer stored across sessions

## Notes

**`sheldon lock` and SSH**: sheldon uses `libgit2` internally, which picks up the `url.insteadOf = https://github.com/` → `ssh://git@github.com/` rewrite from gitconfig but does **not** read `~/.ssh/config`. To make `sheldon lock` work with SSH:

1. Add GitHub's host key for `libgit2` (which connects on port 22, ignoring any `~/.ssh/config` port overrides):
   ```bash
   ssh-keyscan github.com >> ~/.ssh/known_hosts
   ```
2. Ensure the SSH key is loaded in the agent:
   ```bash
   ssh-add ~/.ssh/id_ed25519
   ```
3. On macOS, add `AddKeysToAgent yes` + `UseKeychain yes` to `~/.ssh/config` so the key persists across reboots.