### PR TITLE
feat(herdr): add session-state hook and config package

### DIFF
--- a/claude/scripts/herdr-agent-state.sh
+++ b/claude/scripts/herdr-agent-state.sh
@@ -3,10 +3,13 @@ set -euo pipefail
 
 readonly HERDR_HOOK="${HOME}/.claude/hooks/herdr-agent-state.sh"
 
+# SessionStart hook stdout is injected into the model's context, so the
+# fallback guidance below goes to stderr instead of spamming every session
+# for users who don't have herdr installed.
 if [[ -f "${HERDR_HOOK}" ]]; then
   bash "${HERDR_HOOK}" session
 elif command -v herdr >/dev/null 2>&1; then
-  echo "Please run 'herdr integration install claude' first."
+  echo "Please run 'herdr integration install claude' first." >&2
 else
-  echo "herdr is not installed in this machine. Please install it by running 'brew install herdr'"
+  echo "herdr is not installed in this machine. Please install it by running 'brew install herdr'" >&2
 fi

--- a/claude/scripts/herdr-agent-state.sh
+++ b/claude/scripts/herdr-agent-state.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly HERDR_HOOK="${HOME}/.claude/hooks/herdr-agent-state.sh"
+
+if [[ -f "${HERDR_HOOK}" ]]; then
+  bash "${HERDR_HOOK}" session
+elif command -v herdr >/dev/null 2>&1; then
+  echo "Please run 'herdr integration install claude' first."
+else
+  echo "herdr is not installed in this machine. Please install it by running 'brew install herdr'"
+fi

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -148,7 +148,7 @@
             "type": "command"
           }
         ],
-        "matcher": "*"
+        "matcher": ""
       }
     ],
     "Notification": [

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -139,6 +139,18 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bash ~/.claude/scripts/herdr-agent-state.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
     "Notification": [
       {
         "matcher": "",

--- a/herdr/.config/herdr/config.toml
+++ b/herdr/.config/herdr/config.toml
@@ -1,0 +1,13 @@
+onboarding = false
+
+[keys]
+prefix = "ctrl+t"
+rename_tab = "prefix+,"
+detach = ["prefix+d", "prefix+q"]
+
+[theme]
+name = "nord"
+auto_switch = false
+
+[ui]
+agent_panel_sort = "spaces"

--- a/up
+++ b/up
@@ -86,6 +86,7 @@ function run_stow()
           bat \
           gh \
           git \
+          herdr \
           nvim \
           starship \
           tmux \

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -4,6 +4,11 @@
 # editor module: emacs key bindings
 bindkey -e
 
+# Some terminals (e.g. herdr) send raw ESC[1;3D / ESC[1;3C for Option+Left/Right
+# instead of moving by word. https://herdr.dev/ja/docs/troubleshooting/
+bindkey $'\e[1;3D' backward-word
+bindkey $'\e[1;3C' forward-word
+
 # directory module: cd convenience options
 setopt AUTO_CD
 setopt AUTO_PUSHD


### PR DESCRIPTION
## Summary

- Add `claude/scripts/herdr-agent-state.sh`, which delegates to herdr's installed Claude Code integration hook (`~/.claude/hooks/herdr-agent-state.sh`) when present
- Fall back to actionable guidance when herdr's Claude integration isn't installed, or when herdr itself isn't installed on the machine
- Wire the script up as a `SessionStart` hook in `claude/settings.json`
- Track herdr's `config.toml` as a new `herdr` stow package and register it in `up`'s stow list

## Why

Setting up herdr (a terminal workspace manager for AI coding agents) as part of this terminal workflow. herdr reports Claude Code session state over its socket API so it can track pane/agent status, but that only happens if its Claude integration hook is installed and invoked on session start — this wires that up automatically wherever these dotfiles are applied. herdr's own `config.toml` is tracked the same way other tool configs (git, tmux, ...) already are in this repo, so it travels with the rest of the setup instead of being a manual, per-machine step.

## Changes

- `claude/scripts/herdr-agent-state.sh`: new script with a three-way branch
  - hook installed → delegate: `bash ~/.claude/hooks/herdr-agent-state.sh session`
  - herdr installed but integration not installed → print `herdr integration install claude` guidance
  - herdr not installed → print `brew install herdr` guidance
- `claude/settings.json`: register the script as a `SessionStart` hook (`matcher: "*"`, `timeout: 10`)
- `herdr/.config/herdr/config.toml`: new stow package tracking herdr's config
- `up`: register the `herdr` package in the stow list

## Test Plan

- [x] Ran the script with the real hook present (`~/.claude/hooks/herdr-agent-state.sh` exists) — exits 0
- [x] Simulated hook missing + herdr installed (fake `$HOME`) — prints `herdr integration install claude` guidance
- [x] Simulated hook missing + herdr not installed (fake `$HOME` + stripped `$PATH`) — prints `brew install herdr` guidance
- [x] Simulated a `SessionStart` hook invocation with sample JSON on stdin — exits 0
- [x] Verified `herdr/.config/herdr/config.toml` matches the live, already-symlinked config exactly