### PR TITLE
feat(zsh): support Herdr in four-panes command

### DIFF
--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -203,13 +203,26 @@ function ide() {
   tmux select-pane -t 0
 }
 
-# Setup tmux panes (4 panes)
+# Setup 4 panes (tmux, or Herdr when HERDR_ENV=1)
 function four-panes() {
-  tmux split-window -h -l 50%
-  tmux select-pane -t 0
-  tmux split-window -v -l 50%
-  tmux select-pane -t 2
-  tmux split-window -v -l 50%
+  if [ "${HERDR_ENV:-}" = "1" ]; then
+    local current_id="${HERDR_PANE_ID}"
+    local top_right_id bottom_left_id bottom_right_id
+    top_right_id=$(herdr pane split --current --direction right --ratio 0.5 --no-focus | jq -r '.result.pane.pane_id')
+    bottom_left_id=$(herdr pane split --current --direction down --ratio 0.5 --no-focus | jq -r '.result.pane.pane_id')
+    bottom_right_id=$(herdr pane split --pane "${top_right_id}" --direction down --ratio 0.5 --no-focus | jq -r '.result.pane.pane_id')
+
+    herdr pane rename "${current_id}" "claude-worker"
+    herdr pane rename "${top_right_id}" "hunk"
+    herdr pane rename "${bottom_left_id}" "claude-reviewer"
+    herdr pane rename "${bottom_right_id}" "work-space-for-human"
+  else
+    tmux split-window -h -l 50%
+    tmux select-pane -t 0
+    tmux split-window -v -l 50%
+    tmux select-pane -t 2
+    tmux split-window -v -l 50%
+  fi
 }
 
 # Print 256 colors


### PR DESCRIPTION
## Summary

- Add a Herdr branch to the `four-panes` shell function, activated when `HERDR_ENV=1`
- Splits into the same 4-pane layout as the tmux version, using the Herdr CLI
- Names each pane: claude-worker (top-left), hunk (top-right), claude-reviewer (bottom-left), work-space-for-human (bottom-right)
- Keeps focus on the first pane (claude-worker) after the layout is set up
- Existing tmux implementation is left untouched for backward compatibility

## Why

I'm migrating my terminal multiplexer setup from tmux to Herdr, but haven't fully committed to dropping tmux yet. I want the same 4-pane workflow I rely on today to also work under Herdr, with named panes so it's clear at a glance what each pane is for.

## Changes

- `zsh/.config/zsh/.zshrc`: `four-panes()` now branches on `HERDR_ENV`. The Herdr path uses `herdr pane split`/`herdr pane rename` to build and label the 2x2 layout; the tmux path is unchanged.

## Test Plan

- [x] Ran `four-panes` inside an active Herdr session and confirmed the 4 panes are created and labeled correctly
- [x] Confirmed focus stays on the first pane (claude-worker) after the split
- [x] `zsh -n` syntax check on `.zshrc`