### PR TITLE
chore: tune claude, herdr, and hunk configs

### DIFF
--- a/claude/scripts/notification.ts
+++ b/claude/scripts/notification.ts
@@ -172,6 +172,9 @@ async function main() {
 }
 
 if (import.meta.main) {
+  if (process.env.HERDR_ENV === "1") {
+    process.exit(0);
+  }
   main().catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     writeLog(`[error] unexpected error: ${message}`);

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -190,14 +190,14 @@
     ],
     "SessionStart": [
       {
+        "matcher": "",
         "hooks": [
           {
+            "type": "command",
             "command": "bash ~/.claude/scripts/herdr-agent-state.sh",
-            "timeout": 10,
-            "type": "command"
+            "timeout": 10
           }
-        ],
-        "matcher": ""
+        ]
       }
     ],
     "Notification": [
@@ -242,7 +242,7 @@
     }
   },
   "language": "Japanese",
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "autoUpdatesChannel": "latest",
   "tui": "fullscreen",
   "prefersReducedMotion": true,

--- a/herdr/.config/herdr/config.toml
+++ b/herdr/.config/herdr/config.toml
@@ -20,7 +20,8 @@ auto_switch = false
 # Override individual color tokens on top of the base theme.
 # Accepts: hex (#rrggbb), named colors, rgb(r,g,b), or panel_bg = "reset"
 [theme.custom]
-overlay0 = "#eeeeee"
+overlay0 = "#d8dee9"
+surface_dim = "#434c5e"
 # panel_bg = "reset"
 # accent = "#f5c2e7"
 # red = "#ff6188"
@@ -69,8 +70,8 @@ prefix = "ctrl+t"
 detach = "prefix+d"
 # reload_config = "prefix+shift+r"
 # open_notification_target = "prefix+o"
-# workspace_picker = "prefix+w"
-# goto = "prefix+g"
+workspace_picker = ""
+goto = "prefix+w"
 # new_workspace = "prefix+shift+n"
 # new_worktree = "prefix+shift+g"
 # open_worktree = ""    # optional, unset by default

--- a/hunk/.config/hunk/config.toml
+++ b/hunk/.config/hunk/config.toml
@@ -8,4 +8,4 @@ wrap_lines = false
 menu_bar = true
 agent_notes = false
 prompt_save_view_preferences = true
-transparent_background = false
+transparent_background = true


### PR DESCRIPTION
## Summary

- Raise Claude Code's default effort level from `high` to `xhigh`
- Tune Herdr theme colors and remap the workspace picker keybind to `goto`
- Enable transparent background in Hunk
- Fix Claude's notification hook to exit 0 when running under Herdr (`HERDR_ENV=1`)

## Why

Personal dotfiles tuning: adjusting default tool behavior/appearance and
closing a gap where the notification hook could return a non-zero exit
code while running inside Herdr's environment, where GUI notifications
aren't applicable.

## Changes

- `claude/settings.json`: `effortLevel` `high` → `xhigh`
- `herdr/.config/herdr/config.toml`: update `overlay0`, add `surface_dim`,
  move `workspace_picker` keybind to `goto`
- `hunk/.config/hunk/config.toml`: `transparent_background` → `true`
- `claude/scripts/notification.ts`: short-circuit to exit code 0 when
  `HERDR_ENV=1`, resolving the existing TODO

## Test Plan

- [x] `bun build` on `notification.ts` succeeds with no type errors
- [x] Verified `HERDR_ENV=1 bun claude/scripts/notification.ts` exits with code 0
- [x] Manually reviewed diffs for the config value changes