### PR TITLE
chore(up): remove completed XDG migration script

### DIFF
--- a/up
+++ b/up
@@ -44,6 +44,12 @@ function run_stow()
         echo "Making symlinks of dot files..."
         echo
 
+        # Ensure ~/.config/zsh is a real directory before stow runs. Without this,
+        # stow tree-folds the new package and links ~/.config/zsh straight to the
+        # repo, causing machine-local files (e.g. credentials.zsh) to be written
+        # inside the dotfiles checkout.
+        mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+
         stow -R -vvv \
           alacritty \
           any-script-mcp \

--- a/up
+++ b/up
@@ -38,34 +38,6 @@ function install_sheldon_plugins()
     fi
 }
 
-# One-time migration of machine-local files into XDG locations.
-# The `mkdir -p` runs every invocation (idempotent); the credentials move runs
-# only when the legacy file exists and no regular file is already at the XDG
-# destination, so re-running after a successful migration is a no-op.
-function migrate_to_xdg()
-{
-    local xdg_config="${XDG_CONFIG_HOME:-$HOME/.config}"
-
-    # Ensure ~/.config/zsh is a real directory before stow runs. Without this,
-    # stow tree-folds the new package and links ~/.config/zsh straight to the
-    # repo, causing machine-local files (e.g. credentials.zsh) to be written
-    # inside the dotfiles checkout.
-    mkdir -p "$xdg_config/zsh"
-
-    # credentials: ~/.credentials.zsh -> $ZDOTDIR/credentials.zsh
-    # Use `-f` (not `-e`) on the destination so a broken symlink there does not
-    # mask the migration.
-    if [ -f "$HOME/.credentials.zsh" ] && [ ! -f "$xdg_config/zsh/credentials.zsh" ]; then
-        echo "Migrating ~/.credentials.zsh -> $xdg_config/zsh/credentials.zsh"
-        mv "$HOME/.credentials.zsh" "$xdg_config/zsh/credentials.zsh" || {
-            echo "ERROR: Failed to migrate ~/.credentials.zsh -> $xdg_config/zsh/credentials.zsh" >&2
-            echo "       Your credentials file is still at ~/.credentials.zsh — no data was lost." >&2
-            echo "       Check permissions on $xdg_config/zsh/ and retry." >&2
-            return 1
-        }
-    fi
-}
-
 function run_stow()
 {
     if type stow > /dev/null 2>&1; then
@@ -175,7 +147,6 @@ function main()
             install_sheldon_plugins
             ;;
         "dot" | "dots" | "stow")
-            migrate_to_xdg
             run_stow
             ;;
         "brew")
@@ -187,7 +158,6 @@ function main()
         *)
             install_homebrew
             install_sheldon_plugins
-            migrate_to_xdg
             run_stow
             install_global_npm_packages
             ;;


### PR DESCRIPTION
## Summary

- Removes the `migrate_to_xdg` function from `up` along with its two call sites in `main()`

## Why

The XDG Base Directory migration (issue #138) is complete on every machine using this repo, so the one-time migration script that moved `~/.credentials.zsh` into the XDG config location is no longer needed. Keeping it around only adds dead code to maintain.

## Changes

- Delete the `migrate_to_xdg` function definition and its comment block
- Remove its invocation from the `dot|dots|stow` case and the default case in `main()`
- Restore `mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/zsh"` in `run_stow()` before the `zsh` stow call — flagged in review: it wasn't part of the one-time migration but a standing precondition that keeps `stow` from tree-folding `~/.config/zsh` into a symlink on a fresh machine, which would write machine-local files like `credentials.zsh` into the git-tracked checkout

## Test Plan

- [x] `zsh -n up` passes (syntax check)
- [x] Searched the repo for other XDG-migration-related scripts/references — none found (only historical planning docs under `.ai_logs`, which are kept as records)
- [x] Verified with a sandboxed GNU Stow run that the restored `mkdir` keeps `~/.config/zsh` a real directory instead of a tree-folded symlink
