### PR TITLE
fix(up): guard gh and alacritty config dirs from stow tree-fold

### DIFF
--- a/up
+++ b/up
@@ -46,11 +46,14 @@ function run_stow()
 
         # Ensure these config directories are real directories before stow runs.
         # Without this, stow tree-folds the package and links the whole directory
-        # straight to the repo, causing machine-local or runtime-generated files
-        # to be written inside the dotfiles checkout — e.g. zsh/credentials.zsh,
-        # gh/hosts.yml (holds auth tokens), or alacritty's auto-generated .bak files.
+        # straight to the repo, causing machine-local or runtime-generated files to
+        # be written physically inside the dotfiles checkout — e.g. zsh/credentials.zsh,
+        # gh/hosts.yml (holds auth tokens), alacritty's auto-generated .bak files, or
+        # herdr/hunk's session and log files. None of gh/herdr/hunk's runtime files
+        # are covered by a gitignore rule (unlike zsh's credentials.zsh or alacritty's
+        # *.bak), so a tree-fold there would leave them tracked-checkout-visible.
         local xdg_config="${XDG_CONFIG_HOME:-$HOME/.config}"
-        mkdir -p "$xdg_config/zsh" "$xdg_config/gh" "$xdg_config/alacritty"
+        mkdir -p "$xdg_config/zsh" "$xdg_config/gh" "$xdg_config/alacritty" "$xdg_config/herdr" "$xdg_config/hunk"
 
         stow -R -vvv \
           alacritty \

--- a/up
+++ b/up
@@ -44,11 +44,13 @@ function run_stow()
         echo "Making symlinks of dot files..."
         echo
 
-        # Ensure ~/.config/zsh is a real directory before stow runs. Without this,
-        # stow tree-folds the new package and links ~/.config/zsh straight to the
-        # repo, causing machine-local files (e.g. credentials.zsh) to be written
-        # inside the dotfiles checkout.
-        mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+        # Ensure these config directories are real directories before stow runs.
+        # Without this, stow tree-folds the package and links the whole directory
+        # straight to the repo, causing machine-local or runtime-generated files
+        # to be written inside the dotfiles checkout — e.g. zsh/credentials.zsh,
+        # gh/hosts.yml (holds auth tokens), or alacritty's auto-generated .bak files.
+        local xdg_config="${XDG_CONFIG_HOME:-$HOME/.config}"
+        mkdir -p "$xdg_config/zsh" "$xdg_config/gh" "$xdg_config/alacritty"
 
         stow -R -vvv \
           alacritty \

--- a/up
+++ b/up
@@ -49,9 +49,10 @@ function run_stow()
         # straight to the repo, causing machine-local or runtime-generated files to
         # be written physically inside the dotfiles checkout — e.g. zsh/credentials.zsh,
         # gh/hosts.yml (holds auth tokens), alacritty's auto-generated .bak files, or
-        # herdr/hunk's session and log files. None of gh/herdr/hunk's runtime files
-        # are covered by a gitignore rule (unlike zsh's credentials.zsh or alacritty's
-        # *.bak), so a tree-fold there would leave them tracked-checkout-visible.
+        # herdr/hunk's session and log files. gh's hosts.yml is covered by a gitignore
+        # rule (**/.config/gh/hosts.yml), but zsh's credentials.zsh and herdr/hunk's
+        # runtime files are not, so a tree-fold there would leave them sitting in the
+        # checkout as regular tracked-looking files.
         local xdg_config="${XDG_CONFIG_HOME:-$HOME/.config}"
         mkdir -p "$xdg_config/zsh" "$xdg_config/gh" "$xdg_config/alacritty" "$xdg_config/herdr" "$xdg_config/hunk"
 


### PR DESCRIPTION
## Summary

- Extends the `mkdir -p` guard in `run_stow()` (added for `zsh` in PR #174) to also cover `~/.config/gh`, `~/.config/alacritty`, `~/.config/herdr`, and `~/.config/hunk`

## Why

While reviewing PR #174, we noticed the same stow tree-fold risk that affected `zsh` could also affect other stow packages. Investigating further:

- `gh`: `gh auth login` writes `hosts.yml` (holds auth tokens) into `~/.config/gh`. If that directory doesn't exist yet on a fresh machine, `stow` tree-folds the `gh` package and symlinks the whole directory into the repo checkout, so `hosts.yml` would land physically inside the checkout. (Gitignore already covers this path via `**/.config/gh/hosts.yml`, so it wouldn't get git-tracked — but a plaintext token still sitting inside the checkout is a real risk on its own: `git add -f` accidents, full-repo tar/rsync, editor/tool indexing, etc.)
- `alacritty`: same tree-fold mechanism applies. Confirmed on this machine that `~/.config/alacritty` is in fact a symlink into the repo today, which is the tree-fold behavior we're guarding against — runtime-generated files (e.g. alacritty's own `.bak` backups) could land inside the checkout the same way.
- `herdr` and `hunk` (added in review of this PR): same exposure as gh/alacritty. Their runtime files (`session.json`, `herdr-client.log`, `herdr-server.log`, `.plugins.lock`, `herdr.sock`, `hunk/state.json`) aren't covered by any gitignore rule — same as zsh's `credentials.zsh` in that respect; only alacritty's `*.bak` and gh's `hosts.yml` have an existing rule. Verified with `git check-ignore` that none of herdr/hunk's runtime files match an existing rule, so a tree-fold here would leave them sitting in the checkout as regular tracked-looking files.

## Changes

- Generalize the existing zsh-only `mkdir -p` in `run_stow()` into `mkdir -p "$xdg_config/zsh" "$xdg_config/gh" "$xdg_config/alacritty" "$xdg_config/herdr" "$xdg_config/hunk"`, using the same `XDG_CONFIG_HOME`-aware path
- Update the comment to describe the shared risk across all five packages and call out that gh/herdr/hunk's runtime files have no gitignore safety net

## Test Plan

- [x] `zsh -n up` passes (syntax check)
- [x] Confirmed `alacritty.toml.2e123a30.bak` in this checkout was never actually committed (covered by a `*.bak` rule in the global git ignore), so no file removal was needed for that artifact
- [x] Confirmed via `git check-ignore` that herdr's and hunk's runtime files (session.json, logs, .plugins.lock, sockets, state.json) match no gitignore rule

## Notes

- This machine's `~/.config/alacritty` is already tree-folded into a symlink from a prior `./up` run. This PR's `mkdir -p` guard prevents the issue on fresh machines going forward, but it doesn't self-heal an already-symlinked directory (same known limitation noted in PR #174). Fixing this machine's existing symlink is a separate, manual step outside this PR's scope. (`~/.config/herdr` and `~/.config/hunk` are real directories on this machine already, so they aren't currently affected here.)
- `bat`/`git`/`starship`/`nvim` were assessed as lower risk (single-file packages, or runtime data goes to XDG cache/state dirs instead) and are left untouched for now.
- `vscode`/`cursor`/`claude` packages stow with an explicit `-t` target and weren't audited here; same tree-fold mechanism could apply to them on a machine where the target doesn't exist yet. Flagged as a possible follow-up, out of scope for this PR.

