### PR TITLE
fix(alacritty): send plain enter for ctrl/command+return

### DIFF
--- a/alacritty/.config/alacritty/alacritty.toml
+++ b/alacritty/.config/alacritty/alacritty.toml
@@ -64,5 +64,15 @@ y = 0
 
 [[keyboard.bindings]]
 key = "Return"
+mods = "Control"
+chars = "\r"
+
+[[keyboard.bindings]]
+key = "Return"
+mods = "Command"
+chars = "\r"
+
+[[keyboard.bindings]]
+key = "Return"
 mods = "Shift"
 chars = "\u001B\r"


### PR DESCRIPTION
## Summary

- Add explicit Alacritty keyboard bindings for Ctrl+Return and Command+Return
- Both now send a plain `\r`, identical to an unmodified Enter

## Why

Pressing Ctrl+Enter or Command+Enter inside Herdr panes did not execute Enter — instead it inserted raw escape sequences (`;5;13~` for Ctrl, `;9;13~` for Command) into the input, breaking any workflow that relies on modifier+Enter behaving like a normal Enter.

## Changes

- `alacritty/.config/alacritty/alacritty.toml`: added `[[keyboard.bindings]]` entries for `mods = "Control"` and `mods = "Command"` on `key = "Return"`, each sending `chars = "\r"`

## Test Plan

- [x] Verified in Herdr that Ctrl+Enter and Command+Enter now execute Enter instead of inserting escape characters
- [x] Validated `alacritty.toml` still parses as valid TOML

## Notes

Root cause: without an explicit override, Alacritty reported these key combinations using xterm's `modifyOtherKeys` extended key-reporting format (`ESC[27;<mod>;13~`). Explicit keyboard bindings take priority over that protocol, so overriding both combinations to send a plain `\r` resolves it.